### PR TITLE
Fix build errors on MacOS

### DIFF
--- a/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
@@ -60,7 +60,7 @@ bool jni_wildcard_query_matches_any_encoded_var (JNIEnv* jni_env, jbyteArray Jav
 
     try {
         return wildcard_query_matches_any_encoded_var<var_placeholder>(
-                wildcard_query, logtype, encoded_vars, encoded_vars_length);
+                wildcard_query, logtype, bit_cast<encoded_variable_t*>(encoded_vars), encoded_vars_length);
     } catch (const ffi::EncodingException& e) {
         JavaIOException::throw_in_java(jni_env, e.what());
         return false;
@@ -109,7 +109,7 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
     auto encoded_vars_length = jni_env->GetArrayLength(Java_encodedVars);
 
     try {
-        auto message = decode_message(logtype, encoded_vars, encoded_vars_length,
+        auto message = decode_message(logtype, bit_cast<encoded_variable_t*>(encoded_vars), encoded_vars_length,
                                       all_dictionary_vars, dictionary_var_end_offsets,
                                       dictionary_var_end_offsets_length);
 

--- a/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
@@ -7,6 +7,7 @@
 #include <cctype>
 #include <climits>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -15,7 +16,6 @@
 
 // Project headers
 #include "../submodules/clp/components/core/src/Defs.h"
-#include "../submodules/clp/components/core/src/Utils.hpp"
 #include "../submodules/clp/components/core/src/ffi/encoding_methods.hpp"
 #include "JavaException.hpp"
 
@@ -143,7 +143,7 @@ JNIEXPORT void JNICALL Java_com_yscope_clp_compressorfrontend_MessageEncoder_enc
     if (false == encoded_vars->empty()) {
         auto java_encoded_variables = jni_env->NewLongArray(encoded_vars->size());
         jni_env->SetLongArrayRegion(java_encoded_variables, 0, encoded_vars->size(),
-                                    encoded_vars->data());
+                                    bit_cast<const jlong*>(encoded_vars->data()));
         jni_env->SetObjectField(Java_encodedMessage, Java_EncodedMessage_encodedVars,
                                 java_encoded_variables);
         encoded_vars->clear();


### PR DESCRIPTION
* Explicitly cast between jlong* and encoded_variable_t*
* Update to the latest version of the clp submodule

<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
MacOS doesn't treat `jlong` and `encoded_variable_t` (`int64_t`) as the same type, so we need to explicitly cast between the two. The latest changes in clp also help to remove unnecessary dependencies for MacOS.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Verified that the package can now build on MacOS.
* Verified unit tests pass.
