### PR TITLE
Enable artifact upload for pull requests in build-lib-for-macos job; disable package publishing for pull requests (fixes #13)

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -43,7 +43,6 @@ jobs:
         uses: ./.github/actions/native-lib-build
 
       - uses: actions/upload-artifact@main
-        if: github.event_name != 'pull_request'
         with:
           name: libclp-ffi-java-macos
           path: ${{github.workspace}}/clp-ffi-*-native-lib/

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -79,7 +79,11 @@ jobs:
           name: libclp-ffi-java-macos
           path: ./target/.
 
-      - name: Build package, run tests, and deploy to GitHub
-        run: mvn --batch-mode deploy -Pgithub_release
+      - name: Build package and run tests
+        run: mvn --batch-mode test
+
+      - name: Deploy to GitHub
+        if: github.event_name != 'pull_request'
+        run: mvn --batch-mode deploy -DskipTests -Pgithub_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#13 

# Validation performed
Verified using personal repo that job no longer fails for pull requests due to the missing artifact.
