### PR TITLE
Update to latest version of clp; Allow user to specify version names for variables schema and encoding methods for validation against the library's versions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 find_package(JNI REQUIRED)
 
 add_library(clp-ffi-java SHARED
+        src/main/cpp/libclp_ffi_java/common.cpp
+        src/main/cpp/libclp_ffi_java/common.hpp
         src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
         src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
         src/main/cpp/libclp_ffi_java/JavaException.cpp
@@ -24,8 +26,8 @@ add_library(clp-ffi-java SHARED
         src/main/cpp/submodules/clp/components/core/src/ffi/encoding_methods.tpp
         src/main/cpp/submodules/clp/components/core/src/string_utils.cpp
         src/main/cpp/submodules/clp/components/core/src/string_utils.hpp
-        target/include/com_yscope_clp_compressorfrontend_MessageEncoder.h
         target/include/com_yscope_clp_compressorfrontend_MessageDecoder.h
+        target/include/com_yscope_clp_compressorfrontend_MessageEncoder.h
         )
 target_compile_features(clp-ffi-java
         PRIVATE cxx_std_17

--- a/src/main/cpp/libclp_ffi_java/JavaException.cpp
+++ b/src/main/cpp/libclp_ffi_java/JavaException.cpp
@@ -4,6 +4,8 @@
 static constexpr char cJavaClassNotFoundExceptionSignature[] = "java/lang/ClassNotFoundException";
 static constexpr char cJavaIOExceptionSignature[] = "java/io/IOException";
 static constexpr char cJavaRuntimeExceptionSignature[] = "java/lang/RuntimeException";
+static constexpr char cJavaUnsupportedOperationException[] =
+        "java/lang/UnsupportedOperationException";
 
 using std::string;
 
@@ -61,6 +63,19 @@ namespace libclp_ffi_java {
                       cJavaRuntimeExceptionSignature, message) {}
 
     void JavaRuntimeException::throw_in_java (JNIEnv* jni_env, const string& message) {
+        JavaException::throw_in_java(jni_env, cJavaRuntimeExceptionSignature, message);
+    }
+
+    JavaUnsupportedOperationException::JavaUnsupportedOperationException (
+            const char* filename,
+            int line_number,
+            JNIEnv* jni_env,
+            const string& message
+    ) : JavaException(ErrorCode_Unsupported, filename, line_number, jni_env,
+                      cJavaUnsupportedOperationException, message) {}
+
+    void JavaUnsupportedOperationException::throw_in_java (JNIEnv* jni_env, const string& message)
+    {
         JavaException::throw_in_java(jni_env, cJavaRuntimeExceptionSignature, message);
     }
 }

--- a/src/main/cpp/libclp_ffi_java/JavaException.hpp
+++ b/src/main/cpp/libclp_ffi_java/JavaException.hpp
@@ -101,6 +101,16 @@ namespace libclp_ffi_java {
         // Methods
         static void throw_in_java (JNIEnv* jni_env, const std::string& message);
     };
+
+    class JavaUnsupportedOperationException : public JavaException {
+    public:
+        // Constructors
+        JavaUnsupportedOperationException (const char* filename, int line_number, JNIEnv* jni_env,
+                                           const std::string& message);
+
+        // Methods
+        static void throw_in_java (JNIEnv* jni_env, const std::string& message);
+    };
 }
 
 #endif // LIBCLP_FFI_JAVA_JAVAEXCEPTION_HPP

--- a/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
@@ -7,6 +7,7 @@
 // Project headers
 #include "../submodules/clp/components/core/src/string_utils.hpp"
 #include "../submodules/clp/components/core/src/ffi/encoding_methods.hpp"
+#include "common.hpp"
 #include "JavaException.hpp"
 
 using ffi::decode_message;
@@ -67,10 +68,21 @@ bool jni_wildcard_query_matches_any_encoded_var (JNIEnv* jni_env, jbyteArray Jav
     }
 }
 
+JNIEXPORT void JNICALL
+Java_com_yscope_clp_compressorfrontend_MessageDecoder_setVariableHandlingRuleVersions (
+        JNIEnv* jni_env,
+        jobject,
+        jbyteArray Java_variablesSchemaVersion,
+        jbyteArray Java_variableEncodingMethodsVersion
+) {
+    libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,
+                                                              Java_variableEncodingMethodsVersion);
+}
+
 JNIEXPORT jbyteArray JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
         JNIEnv* jni_env,
-        jclass,
+        jobject,
         jbyteArray Java_logtype,
         jbyteArray Java_allDictionaryVars,
         jintArray Java_dictionaryVarEndOffsets,
@@ -129,7 +141,7 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
 JNIEXPORT jboolean JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_wildcardQueryMatchesAnyFloatVarNative (
         JNIEnv* jni_env,
-        jclass,
+        jobject,
         jbyteArray Java_wildcard_query,
         jbyteArray Java_logtype,
         jlongArray Java_encoded_vars
@@ -141,7 +153,7 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_wildcardQueryMatchesAnyFlo
 JNIEXPORT jboolean JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_wildcardQueryMatchesAnyIntVarNative (
         JNIEnv* jni_env,
-        jclass,
+        jobject,
         jbyteArray Java_wildcard_query,
         jbyteArray Java_logtype,
         jlongArray Java_encoded_vars

--- a/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
@@ -17,6 +17,7 @@
 // Project headers
 #include "../submodules/clp/components/core/src/Defs.h"
 #include "../submodules/clp/components/core/src/ffi/encoding_methods.hpp"
+#include "common.hpp"
 #include "JavaException.hpp"
 
 using ffi::encode_message;
@@ -94,6 +95,17 @@ JNIEXPORT void JNICALL Java_com_yscope_clp_compressorfrontend_MessageEncoder_ini
     logtype = std::make_unique<string>();
     encoded_vars = std::make_unique<vector<encoded_variable_t>>();
     dictionary_var_bounds = std::make_unique<vector<int32_t>>();
+}
+
+JNIEXPORT void JNICALL
+Java_com_yscope_clp_compressorfrontend_MessageEncoder_setVariableHandlingRuleVersions (
+        JNIEnv* jni_env,
+        jobject,
+        jbyteArray Java_variablesSchemaVersion,
+        jbyteArray Java_variableEncodingMethodsVersion
+) {
+    libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,
+                                                              Java_variableEncodingMethodsVersion);
 }
 
 JNIEXPORT void JNICALL Java_com_yscope_clp_compressorfrontend_MessageEncoder_encodeMessageNative (

--- a/src/main/cpp/libclp_ffi_java/common.cpp
+++ b/src/main/cpp/libclp_ffi_java/common.cpp
@@ -1,0 +1,50 @@
+#include "common.hpp"
+
+// C++ standard libraries
+#include <string_view>
+
+// Project headers
+#include "../submodules/clp/components/core/src/ffi/encoding_methods.hpp"
+#include "JavaException.hpp"
+
+using ffi::cVariableEncodingMethodsVersion;
+using ffi::cVariablesSchemaVersion;
+using std::string_view;
+
+namespace libclp_ffi_java {
+    void validate_variable_handling_rule_versions (
+            JNIEnv* jni_env,
+            jbyteArray Java_variablesSchemaVersion,
+            jbyteArray Java_variableEncodingMethodsVersion
+    ) {
+        // Validate the schemas version
+        auto schema_version_bytes = jni_env->GetByteArrayElements(Java_variablesSchemaVersion,
+                                                                  nullptr);
+        if (nullptr == schema_version_bytes) {
+            return;
+        }
+        auto schema_version_bytes_length = jni_env->GetArrayLength(Java_variablesSchemaVersion);
+        string_view schema_version(reinterpret_cast<const char*>(schema_version_bytes),
+                                   schema_version_bytes_length);
+        if (cVariablesSchemaVersion != schema_version) {
+            JavaUnsupportedOperationException::throw_in_java(jni_env,
+                    "Unsupported version for variables schema");
+        }
+
+        // Validate the encoding methods version
+        auto encoding_methods_version_bytes =
+                jni_env->GetByteArrayElements(Java_variableEncodingMethodsVersion, nullptr);
+        if (nullptr == encoding_methods_version_bytes) {
+            return;
+        }
+        auto encoding_methods_version_length =
+                jni_env->GetArrayLength(Java_variableEncodingMethodsVersion);
+        string_view encoding_methods_version(
+                reinterpret_cast<const char*>(encoding_methods_version_bytes),
+                encoding_methods_version_length);
+        if (cVariableEncodingMethodsVersion != encoding_methods_version) {
+            JavaUnsupportedOperationException::throw_in_java(jni_env,
+                    "Unsupported version for variable encoding methods");
+        }
+    }
+}

--- a/src/main/cpp/libclp_ffi_java/common.hpp
+++ b/src/main/cpp/libclp_ffi_java/common.hpp
@@ -1,0 +1,23 @@
+#ifndef LIBCLP_FFI_JAVA_COMMON_HPP
+#define LIBCLP_FFI_JAVA_COMMON_HPP
+
+// JNI
+#include <jni.h>
+
+namespace libclp_ffi_java {
+    /**
+     * Validates that the given version names for the variables schema and
+     * variable encoding methods match the versions currently used by this
+     * library.
+     * @param jni_env
+     * @param Java_variablesSchemaVersion
+     * @param Java_variableEncodingMethodsVersion
+     */
+    void validate_variable_handling_rule_versions (
+            JNIEnv* jni_env,
+            jbyteArray Java_variablesSchemaVersion,
+            jbyteArray Java_variableEncodingMethodsVersion
+    );
+}
+
+#endif // LIBCLP_FFI_JAVA_COMMON_HPP

--- a/src/main/java/com/yscope/clp/compressorfrontend/BuiltInVariableHandlingRuleVersions.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/BuiltInVariableHandlingRuleVersions.java
@@ -1,0 +1,6 @@
+package com.yscope.clp.compressorfrontend;
+
+public class BuiltInVariableHandlingRuleVersions {
+  public static final String VariablesSchemaV2 = "com.yscope.clp.VariablesSchemaV2";
+  public static final String VariableEncodingMethodsV1 = "com.yscope.clp.VariableEncodingMethodsV1";
+}

--- a/src/main/java/com/yscope/clp/compressorfrontend/MessageDecoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/MessageDecoder.java
@@ -13,6 +13,29 @@ public class MessageDecoder {
   }
 
   /**
+   * Constructs an object for decoding CLP-encoded log messages.
+   * @param variablesSchemaVersion The version of the variables schema used to
+   *                               parse the log messages.
+   * @param variableEncodingMethodsVersion The version of variable encoding
+   *                                       methods used to encode the log
+   *                                       messages.
+   * @throws UnsupportedOperationException if either version was unknown or
+   * unsupported.
+   */
+  public MessageDecoder(
+      String variablesSchemaVersion,
+      String variableEncodingMethodsVersion
+  ) throws UnsupportedOperationException {
+    setVariableHandlingRuleVersions(variablesSchemaVersion.getBytes(StandardCharsets.ISO_8859_1),
+        variableEncodingMethodsVersion.getBytes(StandardCharsets.ISO_8859_1));
+  }
+
+  private native void setVariableHandlingRuleVersions (
+      byte[] variablesSchemaVersion,
+      byte[] variableEncodingMethodsVersion
+  ) throws UnsupportedOperationException;
+
+  /**
    * Decodes the message with the given logtype and variables
    * @param logtype
    * @param dictionaryVars
@@ -20,7 +43,7 @@ public class MessageDecoder {
    * @return The decoded message
    * @throws IOException if decoding fails
    */
-  public static String decodeMessage(
+  public String decodeMessage(
       String logtype,
       String[] dictionaryVars,
       long[] encodedVars
@@ -53,7 +76,7 @@ public class MessageDecoder {
    * @throws IOException if the delimiters in the logtype don't match the number
    * of variables.
    */
-  private static native byte[] decodeMessageNative(byte[] logtype, byte[] allDictionaryVars,
+  private native byte[] decodeMessageNative(byte[] logtype, byte[] allDictionaryVars,
       int[] dictionaryVarEndOffsets, long[] encodedVars) throws IOException;
 
   /**
@@ -64,7 +87,7 @@ public class MessageDecoder {
    * @param encodedVars
    * @return true if a match was found, false otherwise
    */
-  public static boolean wildcardQueryMatchesAnyIntVar(
+  public boolean wildcardQueryMatchesAnyIntVar(
       String wildcardQuery,
       String logtype,
       long[] encodedVars
@@ -73,7 +96,7 @@ public class MessageDecoder {
         logtype.getBytes(StandardCharsets.ISO_8859_1), encodedVars);
   }
 
-  private static native boolean wildcardQueryMatchesAnyIntVarNative(
+  private native boolean wildcardQueryMatchesAnyIntVarNative(
       byte[] wildcardQuery,
       byte[] logtype,
       long[] encodedVars
@@ -86,7 +109,7 @@ public class MessageDecoder {
    * @param encodedVars
    * @return true if a match was found, false otherwise
    */
-  public static boolean wildcardQueryMatchesAnyFloatVar(
+  public boolean wildcardQueryMatchesAnyFloatVar(
       String wildcardQuery,
       String logtype,
       long[] encodedVars
@@ -96,7 +119,7 @@ public class MessageDecoder {
         logtype.getBytes(StandardCharsets.ISO_8859_1), encodedVars);
   }
 
-  private static native boolean wildcardQueryMatchesAnyFloatVarNative(
+  private native boolean wildcardQueryMatchesAnyFloatVarNative(
       byte[] wildcardQuery,
       byte[] logtype,
       long[] encodedVars

--- a/src/main/java/com/yscope/clp/compressorfrontend/MessageEncoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/MessageEncoder.java
@@ -18,6 +18,29 @@ public class MessageEncoder {
   private static native void init();
 
   /**
+   * Constructs an object for encoding log messages using CLP.
+   * @param variablesSchemaVersion The version of the variables schema to use to
+   *                               parse the log messages.
+   * @param variableEncodingMethodsVersion The version of variable encoding
+   *                                       methods to use to encode the log
+   *                                       messages.
+   * @throws UnsupportedOperationException if either version was unknown or
+   * unsupported.
+   */
+  public MessageEncoder(
+      String variablesSchemaVersion,
+      String variableEncodingMethodsVersion
+  ) throws UnsupportedOperationException {
+    setVariableHandlingRuleVersions(variablesSchemaVersion.getBytes(StandardCharsets.ISO_8859_1),
+        variableEncodingMethodsVersion.getBytes(StandardCharsets.ISO_8859_1));
+  }
+
+  private native void setVariableHandlingRuleVersions (
+      byte[] variablesSchemaVersion,
+      byte[] variableEncodingMethodsVersion
+  ) throws UnsupportedOperationException;
+
+  /**
    * Encodes the given log message
    * @param message
    * @param encodedMessage

--- a/src/test/java/com/yscope/clp/compressorfrontend/EncodingTests.java
+++ b/src/test/java/com/yscope/clp/compressorfrontend/EncodingTests.java
@@ -13,24 +13,29 @@ public class EncodingTests {
     try {
       String message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
       EncodedMessage encodedMessage = new EncodedMessage();
-      MessageEncoder messageEncoder = new MessageEncoder();
+      MessageEncoder messageEncoder =
+          new MessageEncoder(BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
+              BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
 
       // Test encoding and decoding
       messageEncoder.encodeMessage(message, encodedMessage);
       String logtypeAsString = new String(encodedMessage.logtype, StandardCharsets.ISO_8859_1);
-      String decodedMessage = MessageDecoder.decodeMessage(
+      MessageDecoder messageDecoder =
+          new MessageDecoder(BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
+              BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
+      String decodedMessage = messageDecoder.decodeMessage(
           logtypeAsString, encodedMessage.getDictionaryVarsAsStrings(),
           encodedMessage.encodedVars);
       assertEquals(message, decodedMessage);
 
       // Test searching encoded variables
-      assertTrue(MessageDecoder.wildcardQueryMatchesAnyIntVar("1*3", logtypeAsString,
+      assertTrue(messageDecoder.wildcardQueryMatchesAnyIntVar("1*3", logtypeAsString,
           encodedMessage.encodedVars));
-      assertFalse(MessageDecoder.wildcardQueryMatchesAnyIntVar("4*7", logtypeAsString,
+      assertFalse(messageDecoder.wildcardQueryMatchesAnyIntVar("4*7", logtypeAsString,
           encodedMessage.encodedVars));
-      assertTrue(MessageDecoder.wildcardQueryMatchesAnyFloatVar("4*7", logtypeAsString,
+      assertTrue(messageDecoder.wildcardQueryMatchesAnyFloatVar("4*7", logtypeAsString,
           encodedMessage.encodedVars));
-      assertFalse(MessageDecoder.wildcardQueryMatchesAnyFloatVar("1*3", logtypeAsString,
+      assertFalse(messageDecoder.wildcardQueryMatchesAnyFloatVar("1*3", logtypeAsString,
           encodedMessage.encodedVars));
     } catch (IOException e) {
       fail(e.getMessage());


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->


# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
* Updates to the latest version of CLP.
* Allows the user to specify the version of the variables schema and variable encoding methods they wish to use. This is useful for them to ensure that they decode variables using the same versions that they used to parse/encode variables. Previously, if the rules changed in the library, the mismatch would not be easily detectable.
* Currently, only one version is supported but this API also allows us to support backward compatibility if necessary.


# Validation performed
<!-- What tests and validation you performed on the change -->
Verified that the unit tests pass.