### PR TITLE
Don't use global variables to avoid allocations between message-encoding calls (fixes #18); Some refactoring:

### DIFF
--- a/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
@@ -13,7 +13,9 @@
 using ffi::decode_message;
 using ffi::VariablePlaceholder;
 using ffi::wildcard_query_matches_any_encoded_var;
+using libclp_ffi_java::cJSizeMax;
 using libclp_ffi_java::JavaIOException;
+using libclp_ffi_java::size_checked_pointer_cast;
 using std::string_view;
 
 /**
@@ -41,7 +43,7 @@ bool jni_wildcard_query_matches_any_encoded_var (JNIEnv* jni_env, jbyteArray Jav
         return false;
     }
     auto logtype_length = jni_env->GetArrayLength(Java_logtype);
-    string_view logtype(reinterpret_cast<const char*>(logtype_bytes), logtype_length);
+    string_view logtype(size_checked_pointer_cast<char>(logtype_bytes), logtype_length);
 
     // Get wildcard query
     auto wildcard_query_bytes = jni_env->GetByteArrayElements(Java_wildcard_query, nullptr);
@@ -49,7 +51,7 @@ bool jni_wildcard_query_matches_any_encoded_var (JNIEnv* jni_env, jbyteArray Jav
         return false;
     }
     auto wildcard_query_length = jni_env->GetArrayLength(Java_wildcard_query);
-    string_view wildcard_query(reinterpret_cast<const char*>(wildcard_query_bytes),
+    string_view wildcard_query(size_checked_pointer_cast<char>(wildcard_query_bytes),
                                wildcard_query_length);
 
     // Get encoded variables
@@ -61,7 +63,7 @@ bool jni_wildcard_query_matches_any_encoded_var (JNIEnv* jni_env, jbyteArray Jav
 
     try {
         return wildcard_query_matches_any_encoded_var<var_placeholder>(
-                wildcard_query, logtype, bit_cast<encoded_variable_t*>(encoded_vars), encoded_vars_length);
+                wildcard_query, logtype, encoded_vars, encoded_vars_length);
     } catch (const ffi::EncodingException& e) {
         JavaIOException::throw_in_java(jni_env, e.what());
         return false;
@@ -94,7 +96,7 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
         return nullptr;
     }
     auto logtype_length = jni_env->GetArrayLength(Java_logtype);
-    string_view logtype(reinterpret_cast<const char*>(logtype_bytes), logtype_length);
+    string_view logtype(size_checked_pointer_cast<char>(logtype_bytes), logtype_length);
 
     // Get dictionary variables
     auto all_dictionary_vars_bytes =
@@ -103,8 +105,8 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
         return nullptr;
     }
     auto all_dictionary_vars_length = jni_env->GetArrayLength(Java_allDictionaryVars);
-    string_view all_dictionary_vars(reinterpret_cast<const char*>(all_dictionary_vars_bytes),
-                                    all_dictionary_vars_length);
+    string_view all_dictionary_vars(size_checked_pointer_cast<char>(all_dictionary_vars_bytes),
+            all_dictionary_vars_length);
 
     auto dictionary_var_end_offsets = jni_env->GetIntArrayElements(Java_dictionaryVarEndOffsets,
                                                                    nullptr);
@@ -121,16 +123,20 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
     auto encoded_vars_length = jni_env->GetArrayLength(Java_encodedVars);
 
     try {
-        auto message = decode_message(logtype, bit_cast<encoded_variable_t*>(encoded_vars), encoded_vars_length,
+        auto message = decode_message(logtype, encoded_vars, encoded_vars_length,
                                       all_dictionary_vars, dictionary_var_end_offsets,
                                       dictionary_var_end_offsets_length);
 
-        auto message_bytes = jni_env->NewByteArray((int)message.length());
+        if (message.length() > cJSizeMax) {
+            JavaIOException::throw_in_java(jni_env, "message can't fit in Java byte array");
+            return nullptr;
+        }
+        auto message_bytes = jni_env->NewByteArray(static_cast<jsize>(message.length()));
         if (nullptr == message_bytes) {
             return nullptr;
         }
-        jni_env->SetByteArrayRegion(message_bytes, 0, (int)message.length(),
-                                    reinterpret_cast<jbyte*>(message.data()));
+        jni_env->SetByteArrayRegion(message_bytes, 0, static_cast<jsize>(message.length()),
+                                    size_checked_pointer_cast<jbyte>(message.data()));
         return message_bytes;
     } catch (const ffi::EncodingException& e) {
         JavaIOException::throw_in_java(jni_env, e.what());

--- a/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
@@ -1,3 +1,6 @@
+// NOTE: Throughout this file, size_checked_pointer_cast from
+// jlong* -> encoded_variable_t* is necessary to resolve build errors on macOS.
+
 // C++ standard libraries
 #include <string>
 
@@ -63,7 +66,8 @@ bool jni_wildcard_query_matches_any_encoded_var (JNIEnv* jni_env, jbyteArray Jav
 
     try {
         return wildcard_query_matches_any_encoded_var<var_placeholder>(
-                wildcard_query, logtype, encoded_vars, encoded_vars_length);
+                wildcard_query, logtype,
+                size_checked_pointer_cast<encoded_variable_t>(encoded_vars), encoded_vars_length);
     } catch (const ffi::EncodingException& e) {
         JavaIOException::throw_in_java(jni_env, e.what());
         return false;
@@ -123,8 +127,10 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
     auto encoded_vars_length = jni_env->GetArrayLength(Java_encodedVars);
 
     try {
-        auto message = decode_message(logtype, encoded_vars, encoded_vars_length,
-                                      all_dictionary_vars, dictionary_var_end_offsets,
+        auto message = decode_message(logtype,
+                                      size_checked_pointer_cast<encoded_variable_t>(encoded_vars),
+                                      encoded_vars_length, all_dictionary_vars,
+                                      dictionary_var_end_offsets,
                                       dictionary_var_end_offsets_length);
 
         if (message.length() > cJSizeMax) {

--- a/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
@@ -1,6 +1,9 @@
-// NOTE: Throughout this file, the size_checked_pointer_cast from jbyte*
-// (signed char*) to char* should be safe since we are comparing the values
-// against ASCII rather than doing arithmetic.
+// NOTE: Throughout this file...
+// - size_checked_pointer_cast from jbyte* (signed char*) to char* should be
+//   safe since we are comparing the values against ASCII rather than doing
+//   arithmetic.
+// - size_checked_pointer_cast from encoded_variable_t* -> jlong* is
+//   necessary to resolve build errors on macOS.
 
 // C++ standard libraries
 #include <memory>
@@ -201,7 +204,7 @@ JNIEXPORT void JNICALL Java_com_yscope_clp_compressorfrontend_MessageEncoder_enc
                 jni_env->NewLongArray(static_cast<jsize>(encoded_vars.size()));
         jni_env->SetLongArrayRegion(java_encoded_variables, 0,
                                     static_cast<jsize>(encoded_vars.size()),
-                                    encoded_vars.data());
+                                    size_checked_pointer_cast<jlong>(encoded_vars.data()));
         jni_env->SetObjectField(Java_encodedMessage, Java_EncodedMessage_encodedVars,
                                 java_encoded_variables);
     }

--- a/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
@@ -1,43 +1,50 @@
-// NOTE: Throughout this file, the reinterpret_cast from jbyte* (signed char*)
-// to char* should be safe since we are comparing the values against ASCII
-// rather than doing arithmetic.
+// NOTE: Throughout this file, the size_checked_pointer_cast from jbyte*
+// (signed char*) to char* should be safe since we are comparing the values
+// against ASCII rather than doing arithmetic.
 
 // C++ standard libraries
-#include <algorithm>
-#include <cctype>
-#include <climits>
-#include <cstring>
 #include <memory>
 #include <string>
 #include <vector>
+
+// CLP
+#include "../submodules/clp/components/core/src/Defs.h"
+#include "../submodules/clp/components/core/src/ffi/encoding_methods.hpp"
 
 // JNI
 #include <com_yscope_clp_compressorfrontend_MessageEncoder.h>
 
 // Project headers
-#include "../submodules/clp/components/core/src/Defs.h"
-#include "../submodules/clp/components/core/src/ffi/encoding_methods.hpp"
 #include "common.hpp"
 #include "JavaException.hpp"
 
 using ffi::encode_message;
+using libclp_ffi_java::cJSizeMax;
 using libclp_ffi_java::JavaClassNotFoundException;
 using libclp_ffi_java::JavaIOException;
 using libclp_ffi_java::JavaRuntimeException;
+using libclp_ffi_java::size_checked_pointer_cast;
 using std::string_view;
 using std::string;
 using std::unique_ptr;
 using std::vector;
 
-jclass Java_EncodedMessage;
-jfieldID Java_EncodedMessage_logtype;
-jfieldID Java_EncodedMessage_dictVarBounds;
-jfieldID Java_EncodedMessage_encodedVars;
+// Constants
+constexpr jint cRequiredJNIVersion = JNI_VERSION_1_6;
 
-unique_ptr<string> logtype;
-unique_ptr<vector<encoded_variable_t>> encoded_vars;
-unique_ptr<vector<int32_t>> dictionary_var_bounds;
+// Globals
+static jclass Java_EncodedMessage = nullptr;
+static jfieldID Java_EncodedMessage_logtype;
+static jfieldID Java_EncodedMessage_dictVarBounds;
+static jfieldID Java_EncodedMessage_encodedVars;
 
+// Local function prototypes
+/**
+ * Caches the field IDs for the Java EncodedMessage class
+ * @param jni_env
+ * @return true on success, false otherwise
+ */
+static bool cache_java_encoded_message_field_ids (JNIEnv* jni_env);
 /**
  * Gets a Java global reference (persists between JNI calls) to the Java class
  * with the given signature
@@ -47,12 +54,33 @@ unique_ptr<vector<int32_t>> dictionary_var_bounds;
  */
 static jclass get_class_global_ref (JNIEnv* jni_env, const char* class_signature);
 
+static bool cache_java_encoded_message_field_ids (JNIEnv* jni_env) {
+    // Get Java class fields
+    // NOTE: GetFieldID already throws Java exceptions, so we don't need to
+    Java_EncodedMessage_logtype = jni_env->GetFieldID(Java_EncodedMessage, "logtype", "[B");
+    if (nullptr == Java_EncodedMessage_logtype) {
+        return false;
+    }
+    Java_EncodedMessage_encodedVars =
+            jni_env->GetFieldID(Java_EncodedMessage, "encodedVars", "[J");
+    if (nullptr == Java_EncodedMessage_encodedVars) {
+        return false;
+    }
+    Java_EncodedMessage_dictVarBounds =
+            jni_env->GetFieldID(Java_EncodedMessage, "dictionaryVarBounds", "[I");
+    if (nullptr == Java_EncodedMessage_dictVarBounds) {
+        return false;
+    }
+
+    return true;
+}
+
 static jclass get_class_global_ref (JNIEnv* jni_env, const char* class_signature) {
     auto local_class_ref = jni_env->FindClass(class_signature);
     if (nullptr == local_class_ref) {
         throw JavaClassNotFoundException(__FILENAME__, __LINE__, jni_env, class_signature);
     }
-    auto global_class_ref = static_cast<jclass>(jni_env->NewGlobalRef(local_class_ref));
+    auto global_class_ref = reinterpret_cast<jclass>(jni_env->NewGlobalRef(local_class_ref));
     if (nullptr == global_class_ref) {
         jni_env->DeleteLocalRef(local_class_ref);
         throw JavaRuntimeException(__FILENAME__, __LINE__, jni_env, "NewGlobalRef failed");
@@ -62,39 +90,39 @@ static jclass get_class_global_ref (JNIEnv* jni_env, const char* class_signature
     return global_class_ref;
 }
 
-JNIEXPORT void JNICALL Java_com_yscope_clp_compressorfrontend_MessageEncoder_init (
-        JNIEnv* jni_env,
-        jclass
-) {
-    // Get Java classes
+JNIEXPORT jint JNICALL JNI_OnLoad (JavaVM* vm, void*) {
+    JNIEnv* jni_env;
+    // Based on the JDK 11 JNI docs, JNI 1.6 should be sufficient for all
+    // JNI methods except those related to modules
+    if (vm->GetEnv(reinterpret_cast<void**>(&jni_env), cRequiredJNIVersion) != JNI_OK) {
+        return JNI_ERR;
+    }
+
+    // Cache JNI objects
     try {
-        Java_EncodedMessage =
-                get_class_global_ref(jni_env, "com/yscope/clp/compressorfrontend/EncodedMessage");
-    } catch (const libclp_ffi_java::JavaException& e) {
+        Java_EncodedMessage = get_class_global_ref(jni_env,
+                "com/yscope/clp/compressorfrontend/EncodedMessage");
+    } catch (libclp_ffi_java::JavaException& e) {
+        return JNI_ERR;
+    }
+    if (cache_java_encoded_message_field_ids(jni_env) == false) {
+        jni_env->DeleteGlobalRef(Java_EncodedMessage);
+        Java_EncodedMessage = nullptr;
+        return JNI_ERR;
+    }
+
+    return cRequiredJNIVersion;
+}
+
+JNIEXPORT void JNICALL JNI_OnUnload (JavaVM* vm, void*) {
+    JNIEnv* jni_env;
+    if (vm->GetEnv(reinterpret_cast<void**>(&jni_env), cRequiredJNIVersion) != JNI_OK) {
+        // Unexpected error, but nothing we can do
         return;
     }
 
-    // Get Java class fields
-    // NOTE: GetFieldID already throws Java exceptions, so we don't need to
-    Java_EncodedMessage_logtype = jni_env->GetFieldID(Java_EncodedMessage, "logtype", "[B");
-    if (nullptr == Java_EncodedMessage_logtype) {
-        return;
-    }
-    Java_EncodedMessage_encodedVars =
-            jni_env->GetFieldID(Java_EncodedMessage, "encodedVars", "[J");
-    if (nullptr == Java_EncodedMessage_encodedVars) {
-        return;
-    }
-    Java_EncodedMessage_dictVarBounds =
-            jni_env->GetFieldID(Java_EncodedMessage, "dictionaryVarBounds", "[I");
-    if (nullptr == Java_EncodedMessage_dictVarBounds) {
-        return;
-    }
-
-    // Initialize globals
-    logtype = std::make_unique<string>();
-    encoded_vars = std::make_unique<vector<encoded_variable_t>>();
-    dictionary_var_bounds = std::make_unique<vector<int32_t>>();
+    jni_env->DeleteGlobalRef(Java_EncodedMessage);
+    Java_EncodedMessage = nullptr;
 }
 
 JNIEXPORT void JNICALL
@@ -120,44 +148,61 @@ JNIEXPORT void JNICALL Java_com_yscope_clp_compressorfrontend_MessageEncoder_enc
         return;
     }
     auto message_length = jni_env->GetArrayLength(Java_message);
-    string_view message(reinterpret_cast<const char*>(message_bytes), message_length);
+    string_view message(size_checked_pointer_cast<char>(message_bytes), message_length);
 
-    if (false == encode_message(message, *logtype, *encoded_vars, *dictionary_var_bounds)) {
+    std::string logtype;
+    std::vector<encoded_variable_t> encoded_vars;
+    std::vector<int32_t> dictionary_var_bounds;
+    if (false == encode_message(message, logtype, encoded_vars, dictionary_var_bounds)) {
         JavaIOException::throw_in_java(jni_env, "message contains variable placeholders");
         return;
     }
 
     // Set encodedMessage.logtype
-    auto Java_logtype = jni_env->NewByteArray(logtype->length());
+    if (logtype.length() > cJSizeMax) {
+        JavaIOException::throw_in_java(jni_env, "logtype too long for byte array");
+        return;
+    }
+    auto Java_logtype = jni_env->NewByteArray(static_cast<jsize>(logtype.length()));
     if (nullptr == Java_logtype) {
         return;
     }
-    jni_env->SetByteArrayRegion(Java_logtype, 0, logtype->length(),
-                                reinterpret_cast<signed char*>(logtype->data()));
+    jni_env->SetByteArrayRegion(Java_logtype, 0, static_cast<jsize>(logtype.length()),
+                                size_checked_pointer_cast<jbyte>(logtype.data()));
     auto exception = jni_env->ExceptionOccurred();
     if (nullptr != exception) {
         return;
     }
     jni_env->SetObjectField(Java_encodedMessage, Java_EncodedMessage_logtype, Java_logtype);
-    logtype->clear();
 
     // Set encodedMessage.dictionaryVarBounds
-    if (false == dictionary_var_bounds->empty()) {
-        auto java_dict_var_bounds = jni_env->NewIntArray(dictionary_var_bounds->size());
-        jni_env->SetIntArrayRegion(java_dict_var_bounds, 0, dictionary_var_bounds->size(),
-                                   dictionary_var_bounds->data());
+    if (false == dictionary_var_bounds.empty()) {
+        if (dictionary_var_bounds.size() > cJSizeMax) {
+            JavaIOException::throw_in_java(jni_env, "dictionaryVarBounds can't fit in Java int "
+                                                    "array");
+            return;
+        }
+        auto java_dict_var_bounds =
+                jni_env->NewIntArray(static_cast<jsize>(dictionary_var_bounds.size()));
+        jni_env->SetIntArrayRegion(java_dict_var_bounds, 0,
+                                   static_cast<jsize>(dictionary_var_bounds.size()),
+                                   dictionary_var_bounds.data());
         jni_env->SetObjectField(Java_encodedMessage, Java_EncodedMessage_dictVarBounds,
                                 java_dict_var_bounds);
-        dictionary_var_bounds->clear();
     }
 
     // Set encodedMessage.encodedVars
-    if (false == encoded_vars->empty()) {
-        auto java_encoded_variables = jni_env->NewLongArray(encoded_vars->size());
-        jni_env->SetLongArrayRegion(java_encoded_variables, 0, encoded_vars->size(),
-                                    bit_cast<const jlong*>(encoded_vars->data()));
+    if (false == encoded_vars.empty()) {
+        if (encoded_vars.size() > cJSizeMax) {
+            JavaIOException::throw_in_java(jni_env, "encodedVars can't fit in Java long array");
+            return;
+        }
+        auto java_encoded_variables =
+                jni_env->NewLongArray(static_cast<jsize>(encoded_vars.size()));
+        jni_env->SetLongArrayRegion(java_encoded_variables, 0,
+                                    static_cast<jsize>(encoded_vars.size()),
+                                    encoded_vars.data());
         jni_env->SetObjectField(Java_encodedMessage, Java_EncodedMessage_encodedVars,
                                 java_encoded_variables);
-        encoded_vars->clear();
     }
 }

--- a/src/main/cpp/libclp_ffi_java/common.hpp
+++ b/src/main/cpp/libclp_ffi_java/common.hpp
@@ -1,10 +1,31 @@
 #ifndef LIBCLP_FFI_JAVA_COMMON_HPP
 #define LIBCLP_FFI_JAVA_COMMON_HPP
 
+// C++ standard libraries
+#include <type_traits>
+
 // JNI
 #include <jni.h>
 
 namespace libclp_ffi_java {
+    // Constants
+    constexpr size_t cJSizeMax = (1ULL << (sizeof(jsize) * 8 - 1)) - 1;
+
+    /**
+     * Cast between pointers after ensuring the source and destination types are
+     * the same size
+     * @tparam Destination The destination type
+     * @tparam Source The source type
+     * @param src The source pointer
+     * @return The casted pointer
+     */
+    template <typename Destination, class Source>
+    std::enable_if_t<sizeof(Destination) == sizeof(Source), Destination*>
+            size_checked_pointer_cast (Source* src)
+    {
+        return reinterpret_cast<Destination*>(src);
+    }
+
     /**
      * Validates that the given version names for the variables schema and
      * variable encoding methods match the versions currently used by this

--- a/src/main/java/com/yscope/clp/compressorfrontend/MessageEncoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/MessageEncoder.java
@@ -9,13 +9,7 @@ import java.nio.charset.StandardCharsets;
 public class MessageEncoder {
   static {
     NativeLibraryLoader.load();
-    init();
   }
-
-  /**
-   * Initializes the native side of the class
-   */
-  private static native void init();
 
   /**
    * Constructs an object for encoding log messages using CLP.


### PR DESCRIPTION
* Use JNI's class-loading and unloading hooks to cache the Java class and method fields (rather than a static method)
* Ensure the data to be copied back to Java will fit in arrays

# References
<!-- Any issues or pull requests relevant to this pull request -->
#18 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
* We no longer use global variables to avoid allocations between consecutive calls to encode messages using `MessageEncoder`.
   * Unfortunately, this results in about a ~20% performance penalty. If we want to resolve this in the future, we can add native state to every instance of the `MessageEncoder`, but the user will need to explicitly clean it up since there's no reliable way to hook into JVM's GC mechanisms.
* In `MessageEncoder`, rather than using a static initialization method, we can use JNI's class loading/unloading hooks to init/deinit thread-safe global variables.
* Added some extra checks to ensure that the data we're copying back to the JVM will fit in arrays. Previously, it could cause an integer overflow of Java's size variables.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Followed the reproduction instructions in #18 and ensured the problem no longer occurred.
