### PR TITLE
Add support for encoding messages into CLP's IR stream format.

### DIFF
--- a/.github/workflows/build-and-release-package.yml
+++ b/.github/workflows/build-and-release-package.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Install requirements
         run: brew install cmake gcc java11 maven
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: recursive
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Install requirements
         run: brew install cmake gcc java11 maven
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: recursive
 
       - uses: actions/setup-java@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
+# Ensure we're compiling for a little-endian machine since we depend on the byte
+# ordering
+include(TestBigEndian)
+TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
+if (IS_BIG_ENDIAN)
+    message(FATAL_ERROR "Big-endian machines are not supported")
+endif()
+
 # Set length of source path for the __FILENAME__ macro
 string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
 add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
@@ -15,8 +23,14 @@ add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 find_package(JNI REQUIRED)
 
 add_library(clp-ffi-java SHARED
+        src/main/cpp/libclp_ffi_java/ClpIrOutputStreamState.hpp
         src/main/cpp/libclp_ffi_java/common.cpp
         src/main/cpp/libclp_ffi_java/common.hpp
+        src/main/cpp/libclp_ffi_java/ir_stream/common.hpp
+        src/main/cpp/libclp_ffi_java/ir_stream/common.tpp
+        src/main/cpp/libclp_ffi_java/Java_AbstractClpIrOutputStream.cpp
+        src/main/cpp/libclp_ffi_java/Java_EightByteClpIrOutputStream.cpp
+        src/main/cpp/libclp_ffi_java/Java_FourByteClpIrOutputStream.cpp
         src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
         src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
         src/main/cpp/libclp_ffi_java/JavaException.cpp
@@ -24,10 +38,17 @@ add_library(clp-ffi-java SHARED
         src/main/cpp/submodules/clp/components/core/src/ffi/encoding_methods.cpp
         src/main/cpp/submodules/clp/components/core/src/ffi/encoding_methods.hpp
         src/main/cpp/submodules/clp/components/core/src/ffi/encoding_methods.tpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/ir_stream/encoding_methods.cpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/ir_stream/encoding_methods.hpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/ir_stream/protocol_constants.hpp
         src/main/cpp/submodules/clp/components/core/src/string_utils.cpp
         src/main/cpp/submodules/clp/components/core/src/string_utils.hpp
+        src/main/cpp/submodules/clp/components/core/src/string_utils.tpp
         target/include/com_yscope_clp_compressorfrontend_MessageDecoder.h
         target/include/com_yscope_clp_compressorfrontend_MessageEncoder.h
+        target/include/com_yscope_clp_irstream_AbstractClpIrOutputStream.h
+        target/include/com_yscope_clp_irstream_EightByteClpIrOutputStream.h
+        target/include/com_yscope_clp_irstream_FourByteClpIrOutputStream.h
         )
 target_compile_features(clp-ffi-java
         PRIVATE cxx_std_17

--- a/src/main/cpp/libclp_ffi_java/ClpIrOutputStreamState.hpp
+++ b/src/main/cpp/libclp_ffi_java/ClpIrOutputStreamState.hpp
@@ -1,0 +1,21 @@
+#ifndef LIBCLP_FFI_JAVA_CLPIROUTPUTSTREAMSTATE_HPP
+#define LIBCLP_FFI_JAVA_CLPIROUTPUTSTREAMSTATE_HPP
+
+// C++ standard libraries
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace libclp_ffi_java {
+    /**
+     * Struct containing buffers that are reused across multiple IR output
+     * stream calls (to avoid reallocations).
+     */
+    struct ClpIrOutputStreamState {
+    public:
+        std::string logtype;
+        std::vector<int8_t> ir_buffer;
+    };
+}
+
+#endif //LIBCLP_FFI_JAVA_CLPIROUTPUTSTREAMSTATE_HPP

--- a/src/main/cpp/libclp_ffi_java/Java_AbstractClpIrOutputStream.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_AbstractClpIrOutputStream.cpp
@@ -1,0 +1,33 @@
+// CLP
+#include "../submodules/clp/components/core/src/ffi/ir_stream/protocol_constants.hpp"
+#include "../submodules/clp/components/core/src/type_utils.hpp"
+
+// JNI
+#include <com_yscope_clp_irstream_AbstractClpIrOutputStream.h>
+
+// Project headers
+#include "ClpIrOutputStreamState.hpp"
+
+using libclp_ffi_java::ClpIrOutputStreamState;
+
+JNIEXPORT jlong JNICALL
+Java_com_yscope_clp_irstream_AbstractClpIrOutputStream_createNativeState (JNIEnv*, jobject) {
+    // NOTE: The use of uintptr_t means that if for some reason,
+    // sizeof(jlong) < sizeof(void*) but sizeof(jlong) == sizeof(uintptr_t),
+    // then this conversion will still work.
+    return bit_cast<jlong>(reinterpret_cast<uintptr_t>(new ClpIrOutputStreamState()));
+}
+
+JNIEXPORT void JNICALL
+Java_com_yscope_clp_irstream_AbstractClpIrOutputStream_destroyNativeState (
+        JNIEnv*,
+        jobject,
+        jlong state_address
+) {
+    delete reinterpret_cast<ClpIrOutputStreamState*>(bit_cast<uintptr_t>(state_address));
+}
+
+JNIEXPORT jbyte JNICALL
+Java_com_yscope_clp_irstream_AbstractClpIrOutputStream_getEofByte (JNIEnv*, jobject) {
+    return ffi::ir_stream::cProtocol::Eof;
+}

--- a/src/main/cpp/libclp_ffi_java/Java_EightByteClpIrOutputStream.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_EightByteClpIrOutputStream.cpp
@@ -1,0 +1,63 @@
+// C++ standard libraries
+#include <string_view>
+
+// CLP
+#include "../submodules/clp/components/core/src/ffi/ir_stream/encoding_methods.hpp"
+#include "../submodules/clp/components/core/src/type_utils.hpp"
+
+// JNI
+#include <com_yscope_clp_irstream_EightByteClpIrOutputStream.h>
+
+// Project headers
+#include "ClpIrOutputStreamState.hpp"
+#include "common.hpp"
+#include "ir_stream/common.hpp"
+#include "JavaException.hpp"
+
+using ffi::ir_stream::eight_byte_encoding::encode_message;
+using ffi::ir_stream::eight_byte_encoding::encode_preamble;
+using libclp_ffi_java::cJSizeMax;
+using libclp_ffi_java::ClpIrOutputStreamState;
+using libclp_ffi_java::ir_stream::encode_log_event;
+using libclp_ffi_java::JavaIOException;
+using libclp_ffi_java::JavaRuntimeException;
+using libclp_ffi_java::size_checked_pointer_cast;
+using std::string_view;
+
+JNIEXPORT jbyteArray JNICALL
+Java_com_yscope_clp_irstream_EightByteClpIrOutputStream_encodePreambleNative (
+        JNIEnv* jni_env,
+        jobject,
+        jlong stream_state_address,
+        jbyteArray Java_timestampPattern,
+        jint timestamp_pattern_length,
+        jbyteArray Java_timestampPatternSyntax,
+        jint timestamp_pattern_syntax_length,
+        jbyteArray Java_timeZoneId,
+        jint time_zone_id_length
+) {
+    return libclp_ffi_java::ir_stream::encode_preamble<ffi::eight_byte_encoded_variable_t>(
+            jni_env,
+            stream_state_address,
+            Java_timestampPattern,
+            timestamp_pattern_length,
+            Java_timestampPatternSyntax,
+            timestamp_pattern_syntax_length,
+            Java_timeZoneId,
+            time_zone_id_length,
+            0
+    );
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_com_yscope_clp_irstream_EightByteClpIrOutputStream_encodeLogEventNative (
+        JNIEnv* jni_env,
+        jobject,
+        jlong stream_state_address,
+        jlong timestamp,
+        jbyteArray Java_message,
+        jint message_length
+) {
+    return encode_log_event<ffi::eight_byte_encoded_variable_t>(
+            jni_env, stream_state_address, timestamp, Java_message, message_length);
+}

--- a/src/main/cpp/libclp_ffi_java/Java_FourByteClpIrOutputStream.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_FourByteClpIrOutputStream.cpp
@@ -1,0 +1,67 @@
+// C++ standard libraries
+#include <string_view>
+
+// CLP
+#include "../submodules/clp/components/core/src/ffi/ir_stream/encoding_methods.hpp"
+#include "../submodules/clp/components/core/src/type_utils.hpp"
+
+// JNI
+#include <com_yscope_clp_irstream_FourByteClpIrOutputStream.h>
+
+// Project headers
+#include "ClpIrOutputStreamState.hpp"
+#include "common.hpp"
+#include "ir_stream/common.hpp"
+#include "JavaException.hpp"
+
+using ffi::ir_stream::four_byte_encoding::encode_message;
+using ffi::ir_stream::four_byte_encoding::encode_preamble;
+using libclp_ffi_java::cJSizeMax;
+using libclp_ffi_java::ClpIrOutputStreamState;
+using libclp_ffi_java::ir_stream::encode_log_event;
+using libclp_ffi_java::JavaIOException;
+using libclp_ffi_java::JavaRuntimeException;
+using libclp_ffi_java::size_checked_pointer_cast;
+using std::string_view;
+
+JNIEXPORT jbyteArray JNICALL
+Java_com_yscope_clp_irstream_FourByteClpIrOutputStream_encodePreambleNative (
+        JNIEnv* jni_env,
+        jobject,
+        jlong stream_state_address,
+        jbyteArray Java_timestampPattern,
+        jint timestamp_pattern_length,
+        jbyteArray Java_timestampPatternSyntax,
+        jint timestamp_pattern_syntax_length,
+        jbyteArray Java_timeZoneId,
+        jint time_zone_id_length,
+        jlong reference_timestamp
+) {
+    return libclp_ffi_java::ir_stream::encode_preamble<ffi::four_byte_encoded_variable_t>(
+            jni_env,
+            stream_state_address,
+            Java_timestampPattern,
+            timestamp_pattern_length,
+            Java_timestampPatternSyntax,
+            timestamp_pattern_syntax_length,
+            Java_timeZoneId,
+            time_zone_id_length,
+            reference_timestamp
+    );
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_com_yscope_clp_irstream_FourByteClpIrOutputStream_encodeLogEventNative (
+        JNIEnv* jni_env,
+        jobject,
+        jlong stream_state_address,
+        jlong timestamp_delta,
+        jbyteArray Java_message,
+        jint message_length
+) {
+    // NOTE: Although encode_log_event takes `timestamp` as a parameter rather
+    // than `timestamp_delta`, they are the same type and encode_log_event just
+    // passes it through
+    return encode_log_event<ffi::four_byte_encoded_variable_t>(
+            jni_env, stream_state_address, timestamp_delta, Java_message, message_length);
+}

--- a/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
@@ -14,6 +14,7 @@
 #include "JavaException.hpp"
 
 using ffi::decode_message;
+using ffi::eight_byte_encoded_variable_t;
 using ffi::VariablePlaceholder;
 using ffi::wildcard_query_matches_any_encoded_var;
 using libclp_ffi_java::cJSizeMax;
@@ -67,7 +68,9 @@ bool jni_wildcard_query_matches_any_encoded_var (JNIEnv* jni_env, jbyteArray Jav
     try {
         return wildcard_query_matches_any_encoded_var<var_placeholder>(
                 wildcard_query, logtype,
-                size_checked_pointer_cast<encoded_variable_t>(encoded_vars), encoded_vars_length);
+                size_checked_pointer_cast<eight_byte_encoded_variable_t>(encoded_vars),
+                encoded_vars_length
+        );
     } catch (const ffi::EncodingException& e) {
         JavaIOException::throw_in_java(jni_env, e.what());
         return false;
@@ -127,11 +130,14 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
     auto encoded_vars_length = jni_env->GetArrayLength(Java_encodedVars);
 
     try {
-        auto message = decode_message(logtype,
-                                      size_checked_pointer_cast<encoded_variable_t>(encoded_vars),
-                                      encoded_vars_length, all_dictionary_vars,
-                                      dictionary_var_end_offsets,
-                                      dictionary_var_end_offsets_length);
+        auto message = decode_message(
+                logtype,
+                size_checked_pointer_cast<eight_byte_encoded_variable_t>(encoded_vars),
+                encoded_vars_length,
+                all_dictionary_vars,
+                dictionary_var_end_offsets,
+                dictionary_var_end_offsets_length
+        );
 
         if (message.length() > cJSizeMax) {
             JavaIOException::throw_in_java(jni_env, "message can't fit in Java byte array");

--- a/src/main/cpp/libclp_ffi_java/ir_stream/common.cpp
+++ b/src/main/cpp/libclp_ffi_java/ir_stream/common.cpp
@@ -1,0 +1,28 @@
+#include "common.hpp"
+
+// Project headers
+#include "../common.hpp"
+#include "../JavaException.hpp"
+
+namespace libclp_ffi_java::ir_stream {
+    jbyteArray copy_ir_buffer_to_java (JNIEnv* jni_env, const std::vector<int8_t>& ir_buffer) {
+        if (ir_buffer.size() > cJSizeMax) {
+            JavaIOException::throw_in_java(jni_env, "Encoded IR data too long for byte array.");
+            return nullptr;
+        }
+        auto Java_ir_buffer = jni_env->NewByteArray(static_cast<jsize>(ir_buffer.size()));
+        if (nullptr == Java_ir_buffer) {
+            JavaIOException::throw_in_java(jni_env, "[native] Failed to allocate return buffer.");
+            return nullptr;
+        }
+        jni_env->SetByteArrayRegion(Java_ir_buffer, 0, static_cast<jsize>(ir_buffer.size()),
+                                    size_checked_pointer_cast<const jbyte>(ir_buffer.data()));
+        auto exception = jni_env->ExceptionOccurred();
+        if (nullptr != exception) {
+            JavaIOException::throw_in_java(jni_env,
+                                           "[native] Failed to set return buffer content.");
+            return nullptr;
+        }
+        return Java_ir_buffer;
+    }
+}

--- a/src/main/cpp/libclp_ffi_java/ir_stream/common.hpp
+++ b/src/main/cpp/libclp_ffi_java/ir_stream/common.hpp
@@ -1,0 +1,69 @@
+#ifndef LIBCLP_FFI_JAVA_IR_STREAM_COMMON_HPP
+#define LIBCLP_FFI_JAVA_IR_STREAM_COMMON_HPP
+
+// C++ standard libraries
+#include <cstdint>
+#include <vector>
+
+// JNI
+#include <jni.h>
+
+namespace libclp_ffi_java::ir_stream {
+    /**
+     * Encodes the preamble into the IR stream format determined by the given
+     * encoded variable type.
+     * NOTE: On failure, callers should return to Java without calling any other
+     * JNI methods.
+     * @tparam encoded_variable_t Type of the encoded variables used with this
+     * IR stream
+     * @param jni_env
+     * @param stream_state_address
+     * @param Java_timestampPattern
+     * @param timestamp_pattern_length
+     * @param Java_timestampPatternSyntax
+     * @param timestamp_pattern_syntax_length
+     * @param Java_timeZoneId
+     * @param time_zone_id_length
+     * @param reference_timestamp For the four-byte encoding, the timestamp
+     * that the first log message's timestamp delta is calculated from. For the
+     * eight-byte encoding, this is unused.
+     * @return A reference to the encoded preamble on success, nullptr
+     * otherwise.
+     */
+    template <typename encoded_variable_t>
+    jbyteArray encode_preamble (
+            JNIEnv* jni_env,
+            jlong stream_state_address,
+            jbyteArray Java_timestampPattern,
+            jint timestamp_pattern_length,
+            jbyteArray Java_timestampPatternSyntax,
+            jint timestamp_pattern_syntax_length,
+            jbyteArray Java_timeZoneId,
+            jint time_zone_id_length,
+            jlong reference_timestamp
+    );
+
+    /**
+     * Encodes the log event into the IR stream format determined by the given
+     * encoded variable type.
+     * NOTE: On failure, callers should return to Java without calling any other
+     * JNI methods.
+     * @tparam encoded_variable_t Type of the encoded variables used with this
+     * IR stream
+     * @param jni_env
+     * @param stream_state_address
+     * @param timestamp_or_timestamp_delta
+     * @param Java_message
+     * @param message_length
+     * @return A reference to the encoded log event on success, nullptr
+     * otherwise.
+     */
+    template <typename encoded_variable_t>
+    jbyteArray encode_log_event (JNIEnv* jni_env, jlong stream_state_address,
+                                 jlong timestamp_or_timestamp_delta, jbyteArray Java_message,
+                                 jint message_length);
+}
+
+#include "common.tpp"
+
+#endif //LIBCLP_FFI_JAVA_IR_STREAM_COMMON_HPP

--- a/src/main/cpp/libclp_ffi_java/ir_stream/common.tpp
+++ b/src/main/cpp/libclp_ffi_java/ir_stream/common.tpp
@@ -1,0 +1,181 @@
+#ifndef LIBCLP_FFI_JAVA_IR_STREAM_COMMON_TPP
+#define LIBCLP_FFI_JAVA_IR_STREAM_COMMON_TPP
+
+// C++ standard libraries
+#include <cstdint>
+#include <vector>
+#include <type_traits>
+
+// JNI
+#include <jni.h>
+
+// Project headers
+#include "../../submodules/clp/components/core/src/type_utils.hpp"
+#include "../../submodules/clp/components/core/src/ffi/encoding_methods.hpp"
+#include "../../submodules/clp/components/core/src/ffi/ir_stream/encoding_methods.hpp"
+#include "../ClpIrOutputStreamState.hpp"
+#include "../common.hpp"
+#include "../JavaException.hpp"
+
+namespace libclp_ffi_java::ir_stream {
+    // Local function prototypes
+    /**
+     * Copies the given IR buffer to Java and returns a reference to it.
+     * NOTE: On failure, callers should return to Java without calling any other
+     * JNI methods.
+     * @param ir_buffer
+     * @param jni_env
+     * @return Reference to the Java buffer on success, nullptr otherwise.
+     */
+    static jbyteArray copy_ir_buffer_to_java (const std::vector<int8_t>& ir_buffer,
+                                              JNIEnv* jni_env);
+
+    template <typename encoded_variable_t>
+    jbyteArray encode_preamble (
+            JNIEnv* jni_env,
+            jlong stream_state_address,
+            jbyteArray Java_timestampPattern,
+            jint timestamp_pattern_length,
+            jbyteArray Java_timestampPatternSyntax,
+            jint timestamp_pattern_syntax_length,
+            jbyteArray Java_timeZoneId,
+            jint time_zone_id_length,
+            jlong reference_timestamp
+    ) {
+        if (timestamp_pattern_length < 0 || timestamp_pattern_syntax_length < 0 ||
+            time_zone_id_length < 0)
+        {
+            JavaRuntimeException::throw_in_java(jni_env,
+                                                "[native] Byte array lengths cannot be negative.");
+            return nullptr;
+        }
+
+        // Get the timestamp pattern
+        auto timestamp_pattern_bytes = jni_env->GetByteArrayElements(Java_timestampPattern,
+                                                                     nullptr);
+        if (nullptr == timestamp_pattern_bytes) {
+            return nullptr;
+        }
+        std::string_view timestamp_pattern{
+                size_checked_pointer_cast<char>(timestamp_pattern_bytes),
+                static_cast<size_t>(timestamp_pattern_length)
+        };
+
+        // Get the timestamp pattern syntax
+        auto timestamp_pattern_syntax_bytes =
+                jni_env->GetByteArrayElements(Java_timestampPatternSyntax, nullptr);
+        if (nullptr == timestamp_pattern_syntax_bytes) {
+            return nullptr;
+        }
+        std::string_view timestamp_pattern_syntax{
+                size_checked_pointer_cast<char>(timestamp_pattern_syntax_bytes),
+                static_cast<size_t>(timestamp_pattern_syntax_length)
+        };
+
+        // Get the time zone ID
+        auto time_zone_id_bytes = jni_env->GetByteArrayElements(Java_timeZoneId, nullptr);
+        if (nullptr == time_zone_id_bytes) {
+            return nullptr;
+        }
+        std::string_view time_zone_id{size_checked_pointer_cast<char>(time_zone_id_bytes),
+                                 static_cast<size_t>(time_zone_id_length)};
+
+        auto stream_state = reinterpret_cast<ClpIrOutputStreamState*>(
+                bit_cast<uintptr_t>(stream_state_address));
+        auto& ir_buffer = stream_state->ir_buffer;
+        ir_buffer.clear();
+        bool encoding_successful;
+        static_assert(std::is_same_v<encoded_variable_t, ffi::eight_byte_encoded_variable_t> ||
+                      std::is_same_v<encoded_variable_t, ffi::four_byte_encoded_variable_t>);
+        if constexpr (std::is_same_v<encoded_variable_t, ffi::eight_byte_encoded_variable_t>) {
+            encoding_successful = ffi::ir_stream::eight_byte_encoding::encode_preamble(
+                    timestamp_pattern, timestamp_pattern_syntax, time_zone_id, ir_buffer
+            );
+        } else {  // std::is_same_v<encoded_variable_t, ffi::four_byte_encoded_variable_t>
+            encoding_successful = ffi::ir_stream::four_byte_encoding::encode_preamble(
+                    timestamp_pattern,
+                    timestamp_pattern_syntax,
+                    time_zone_id,
+                    reference_timestamp,
+                    ir_buffer
+            );
+        }
+        if (false == encoding_successful)
+        {
+            JavaIOException::throw_in_java(jni_env, "Failed to encode preamble.");
+            return nullptr;
+        }
+
+        return libclp_ffi_java::ir_stream::copy_ir_buffer_to_java(ir_buffer, jni_env);
+    }
+
+    template <typename encoded_variable_t>
+    jbyteArray encode_log_event (JNIEnv* jni_env, jlong stream_state_address,
+                                 jlong timestamp_or_timestamp_delta, jbyteArray Java_message,
+                                 jint message_length)
+    {
+        if (message_length < 0) {
+            JavaRuntimeException::throw_in_java(jni_env,
+                                                "[native] Byte array lengths cannot be negative.");
+            return nullptr;
+        }
+
+        // Get the message
+        auto message_bytes = jni_env->GetByteArrayElements(Java_message, nullptr);
+        if (nullptr == message_bytes) {
+            JavaIOException::throw_in_java(jni_env, "[native] Failed to get message.");
+            return nullptr;
+        }
+        std::string_view message{size_checked_pointer_cast<char>(message_bytes),
+                            static_cast<size_t>(message_length)};
+
+        auto stream_state = reinterpret_cast<ClpIrOutputStreamState*>(
+                bit_cast<uintptr_t>(stream_state_address));
+        auto& logtype = stream_state->logtype;
+        auto& ir_buffer = stream_state->ir_buffer;
+        ir_buffer.clear();
+        bool encoding_successful;
+        static_assert(std::is_same_v<encoded_variable_t, ffi::eight_byte_encoded_variable_t> ||
+                      std::is_same_v<encoded_variable_t, ffi::four_byte_encoded_variable_t>);
+        if constexpr (std::is_same_v<encoded_variable_t, ffi::eight_byte_encoded_variable_t>) {
+            encoding_successful = ffi::ir_stream::eight_byte_encoding::encode_message(
+                    timestamp_or_timestamp_delta, message, logtype, ir_buffer
+            );
+        } else {  // std::is_same_v<encoded_variable_t, ffi::four_byte_encoded_variable_t>
+            encoding_successful = ffi::ir_stream::four_byte_encoding::encode_message(
+                    timestamp_or_timestamp_delta, message, logtype, ir_buffer
+            );
+        }
+        if (false == encoding_successful) {
+            JavaIOException::throw_in_java(jni_env, "Failed to encode message.");
+            return nullptr;
+        }
+
+        return copy_ir_buffer_to_java(ir_buffer, jni_env);
+    }
+
+    static jbyteArray copy_ir_buffer_to_java (const std::vector<int8_t>& ir_buffer,
+                                              JNIEnv* jni_env)
+    {
+        if (ir_buffer.size() > cJSizeMax) {
+            JavaIOException::throw_in_java(jni_env, "Encoded IR data too long for byte array.");
+            return nullptr;
+        }
+        auto Java_ir_buffer = jni_env->NewByteArray(static_cast<jsize>(ir_buffer.size()));
+        if (nullptr == Java_ir_buffer) {
+            JavaIOException::throw_in_java(jni_env, "[native] Failed to allocate return buffer.");
+            return nullptr;
+        }
+        jni_env->SetByteArrayRegion(Java_ir_buffer, 0, static_cast<jsize>(ir_buffer.size()),
+                                    size_checked_pointer_cast<const jbyte>(ir_buffer.data()));
+        auto exception = jni_env->ExceptionOccurred();
+        if (nullptr != exception) {
+            JavaIOException::throw_in_java(jni_env,
+                                           "[native] Failed to set return buffer content.");
+            return nullptr;
+        }
+        return Java_ir_buffer;
+    }
+}
+
+#endif //LIBCLP_FFI_JAVA_IR_STREAM_COMMON_TPP

--- a/src/main/java/com/yscope/clp/irstream/AbstractClpIrOutputStream.java
+++ b/src/main/java/com/yscope/clp/irstream/AbstractClpIrOutputStream.java
@@ -1,0 +1,118 @@
+package com.yscope.clp.irstream;
+
+import com.yscope.clp.compressorfrontend.NativeLibraryLoader;
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Base class for CLP IR output streams.
+ */
+public abstract class AbstractClpIrOutputStream implements AutoCloseable, Flushable {
+  protected long nativeStateAddress;
+
+  protected String timestampPattern;
+  protected String timeZoneId;
+
+  private final OutputStream outputStream;
+
+  static {
+    NativeLibraryLoader.load();
+  }
+
+  /**
+   * Abstract constructor for output streams
+   * @param timestampPattern Timestamp pattern used by log events in this stream
+   * @param timeZoneId Time zone of log events in this stream
+   * @param outputStream Stream which IR should be written to
+   */
+  public AbstractClpIrOutputStream (String timestampPattern, String timeZoneId,
+                                    OutputStream outputStream)
+  {
+    this.nativeStateAddress = createNativeState();
+    this.timestampPattern = timestampPattern;
+    this.timeZoneId = timeZoneId;
+    this.outputStream = outputStream;
+  }
+
+  /**
+   * Closes the stream
+   * @throws IOException on I/O error
+   */
+  @Override
+  public void close () throws IOException {
+    outputStream.write(getEofByte());
+    outputStream.close();
+
+    destroyNativeState(nativeStateAddress);
+    nativeStateAddress = 0;
+  }
+
+  /**
+   * Flushes the stream
+   * @throws IOException on I/O error
+   */
+  @Override
+  public void flush () throws IOException {
+    outputStream.flush();
+  }
+
+  /**
+   * Writes the given log event to the stream
+   * @param timestamp Timestamp of the event as milliseconds since the Unix
+   * epoch
+   * @param message
+   * @throws IOException on failure to encode the message or I/O error
+   */
+  public void writeLogEvent (long timestamp, ByteBuffer message) throws IOException {
+    if (0 == nativeStateAddress) {
+      throw new IOException("Stream closed.");
+    }
+
+    if (null != timestampPattern) {
+      byte[] preamble = encodePreamble(timestamp);
+      outputStream.write(preamble);
+      // Clear these members now that they've been written to the preamble
+      timestampPattern = null;
+      timeZoneId = null;
+    }
+
+    byte[] encodedLogEvent = encodeLogEvent(timestamp, message);
+    outputStream.write(encodedLogEvent);
+  }
+
+  /**
+   * Encodes the preamble into the IR stream format
+   * @param firstMessageTimestamp Timestamp of the first message in this stream
+   * @return The encoded preamble
+   * @throws IOException on encode failure
+   */
+  protected abstract byte[] encodePreamble (long firstMessageTimestamp) throws IOException;
+
+  /**
+   * Encodes the log event into the IR stream format
+   * @param timestamp Timestamp of the event as milliseconds from the Unix epoch
+   * @param message
+   * @return The encoded message
+   * @throws IOException on encode failure
+   */
+  protected abstract byte[] encodeLogEvent (long timestamp, ByteBuffer message) throws IOException;
+
+  /**
+   * Creates the native state necessary for this output stream
+   * @return A native address for the state
+   */
+  private native long createNativeState ();
+
+  /**
+   * Destroys this output stream's native state
+   * @param stateAddress The native address of the state
+   */
+  private native void destroyNativeState (long stateAddress);
+
+  /**
+   * @return The EOF byte for the IR stream
+   */
+  private native byte getEofByte ();
+}

--- a/src/main/java/com/yscope/clp/irstream/EightByteClpIrOutputStream.java
+++ b/src/main/java/com/yscope/clp/irstream/EightByteClpIrOutputStream.java
@@ -1,0 +1,86 @@
+package com.yscope.clp.irstream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * CLP IR output stream using the eight-byte encoding
+ */
+public class EightByteClpIrOutputStream extends AbstractClpIrOutputStream {
+  /**
+   * @see AbstractClpIrOutputStream#AbstractClpIrOutputStream
+   */
+  public EightByteClpIrOutputStream (String timestampPattern, String timeZoneId,
+                                     OutputStream outputStream)
+  {
+    super(timestampPattern, timeZoneId, outputStream);
+  }
+
+  @Override
+  protected byte[] encodePreamble (long firstMessageTimestamp) throws IOException {
+    byte[] timestampPatternBytes = timestampPattern.getBytes(StandardCharsets.UTF_8);
+    byte[] timestampPatternSyntaxBytes = "java::SimpleDateFormat".getBytes(StandardCharsets.UTF_8);
+    byte[] timeZoneIdBytes = timeZoneId.getBytes(StandardCharsets.UTF_8);
+    byte[] encoded = encodePreambleNative(nativeStateAddress, timestampPatternBytes,
+                                          timestampPatternBytes.length,
+                                          timestampPatternSyntaxBytes,
+                                          timestampPatternSyntaxBytes.length, timeZoneIdBytes,
+                                          timeZoneIdBytes.length);
+    if (null == encoded) {
+      throw new IOException("Encoding failed.");
+    }
+    return encoded;
+  }
+
+  @Override
+  protected byte[] encodeLogEvent (long timestamp, ByteBuffer message) throws IOException {
+    byte[] messageBytes = message.array();
+    int messageLength = message.limit();
+    byte[] encoded = encodeLogEventNative(nativeStateAddress, timestamp, messageBytes,
+                                          messageLength);
+    if (null == encoded) {
+      throw new IOException("Encoding failed.");
+    }
+    return encoded;
+  }
+
+  /**
+   * Encodes the IR stream's preamble
+   * @param nativeStateAddress
+   * @param timestampPattern
+   * @param timestampPatternLength
+   * @param timestampPatternSyntax
+   * @param timestampPatternSyntaxLength
+   * @param timeZoneId
+   * @param timeZoneIdLength
+   * @return The encoded preamble
+   * @throws IOException on encode failure
+   */
+  private native byte[] encodePreambleNative (
+      long nativeStateAddress,
+      byte[] timestampPattern,
+      int timestampPatternLength,
+      byte[] timestampPatternSyntax,
+      int timestampPatternSyntaxLength,
+      byte[] timeZoneId,
+      int timeZoneIdLength
+  ) throws IOException;
+
+  /**
+   * Encodes the log event
+   * @param nativeStateAddress
+   * @param timestamp Timestamp as milliseconds from the Unix epoch
+   * @param message
+   * @param messageLength
+   * @return The encoded log event
+   * @throws IOException on encode failure
+   */
+  private native byte[] encodeLogEventNative (
+      long nativeStateAddress,
+      long timestamp,
+      byte[] message,
+      int messageLength
+  ) throws IOException;
+}

--- a/src/main/java/com/yscope/clp/irstream/FourByteClpIrOutputStream.java
+++ b/src/main/java/com/yscope/clp/irstream/FourByteClpIrOutputStream.java
@@ -1,0 +1,96 @@
+package com.yscope.clp.irstream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * CLP IR output stream using the four-byte encoding
+ */
+public class FourByteClpIrOutputStream extends AbstractClpIrOutputStream {
+  private long previousMessageTimestamp;
+
+  /**
+   * @see AbstractClpIrOutputStream#AbstractClpIrOutputStream
+   */
+  public FourByteClpIrOutputStream (String timestampPattern, String timeZoneId,
+                                    OutputStream outputStream)
+  {
+    super(timestampPattern, timeZoneId, outputStream);
+    previousMessageTimestamp = 0;
+  }
+
+  @Override
+  protected byte[] encodePreamble (long firstMessageTimestamp) throws IOException {
+    byte[] timestampPatternBytes = timestampPattern.getBytes(StandardCharsets.UTF_8);
+    byte[] timestampPatternSyntaxBytes = "java::SimpleDateFormat".getBytes(StandardCharsets.UTF_8);
+    byte[] timeZoneIdBytes = timeZoneId.getBytes(StandardCharsets.UTF_8);
+    byte[] encoded = encodePreambleNative(nativeStateAddress, timestampPatternBytes,
+                                          timestampPatternBytes.length,
+                                          timestampPatternSyntaxBytes,
+                                          timestampPatternSyntaxBytes.length, timeZoneIdBytes,
+                                          timeZoneIdBytes.length, firstMessageTimestamp);
+    if (null == encoded) {
+      throw new IOException("Encoding failed.");
+    }
+
+    previousMessageTimestamp = firstMessageTimestamp;
+
+    return encoded;
+  }
+
+  @Override
+  protected byte[] encodeLogEvent (long timestamp, ByteBuffer message) throws IOException {
+    byte[] encoded = encodeLogEventNative(nativeStateAddress, timestamp - previousMessageTimestamp,
+                                          message.array(), message.limit());
+    if (null == encoded) {
+      throw new IOException("Encoding failed.");
+    }
+
+    previousMessageTimestamp = timestamp;
+
+    return encoded;
+  }
+
+  /**
+   * Encodes the IR stream's preamble
+   * @param nativeStateAddress
+   * @param timestampPattern
+   * @param timestampPatternLength
+   * @param timestampPatternSyntax
+   * @param timestampPatternSyntaxLength
+   * @param timeZoneId
+   * @param timeZoneIdLength
+   * @param referenceTimestamp The timestamp that the first log message's
+   * timestamp delta is calculated from
+   * @return The encoded preamble
+   * @throws IOException on encode failure
+   */
+  private native byte[] encodePreambleNative (
+      long nativeStateAddress,
+      byte[] timestampPattern,
+      int timestampPatternLength,
+      byte[] timestampPatternSyntax,
+      int timestampPatternSyntaxLength,
+      byte[] timeZoneId,
+      int timeZoneIdLength,
+      long referenceTimestamp
+  ) throws IOException;
+
+  /**
+   * Encodes the log event
+   * @param nativeStateAddress
+   * @param timestampDelta Milliseconds since the previous message's timestamp
+   * @param message
+   * @param messageLength
+   * @return The encoded log event
+   * @throws IOException on encode failure
+   */
+  private native byte[] encodeLogEventNative (
+      long nativeStateAddress,
+      long timestampDelta,
+      byte[] message,
+      int messageLength
+  ) throws IOException;
+}

--- a/src/test/java/com/yscope/clp/irstream/TestClpIrOutputStream.java
+++ b/src/test/java/com/yscope/clp/irstream/TestClpIrOutputStream.java
@@ -1,0 +1,62 @@
+package com.yscope.clp.irstream;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestClpIrOutputStream {
+  @Test
+  void testWritingEightByteEncodedIrStream () {
+    testWritingIrStream(false);
+  }
+
+  @Test
+  void testWritingFourByteEncodedIrStream () {
+    testWritingIrStream(true);
+  }
+
+  private void testWritingIrStream (boolean useFourByteEncoding) {
+    String logMessage = " INFO Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3\n";
+    ByteBuffer logEvent = ByteBuffer.wrap(logMessage.getBytes(StandardCharsets.ISO_8859_1));
+
+    try {
+      String logFilePathString = useFourByteEncoding ? "four-byte.clp" : "eight-byte.clp";
+      Path logFilePath = Paths.get(logFilePathString);
+      OutputStream fileOutputStream = Files.newOutputStream(logFilePath);
+      String timestampPattern = "yyyy-MM-dd HH:mm:ss,SSS";
+      String timeZoneId = ZonedDateTime.now().getZone()
+          .toString();
+      AbstractClpIrOutputStream clpIrOutputStream;
+      if (useFourByteEncoding) {
+        clpIrOutputStream = new FourByteClpIrOutputStream(timestampPattern, timeZoneId,
+                                                          fileOutputStream);
+      } else {
+        clpIrOutputStream = new EightByteClpIrOutputStream(timestampPattern, timeZoneId,
+                                                           fileOutputStream);
+      }
+
+      for (int i = 0; i < 100; ++i) {
+        clpIrOutputStream.writeLogEvent(System.currentTimeMillis(), logEvent);
+      }
+
+      clpIrOutputStream.close();
+
+      File outputFile = new File(logFilePathString);
+      assertTrue(outputFile.exists());
+
+      Files.delete(logFilePath);
+    } catch (IOException e) {
+      fail(e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

* Update to the latest clp commit.
* Add support for encoding messages into CLP's IR stream format (as described in the Uber [blog](https://www.uber.com/blog/reducing-logging-cost-by-two-orders-of-magnitude-using-clp/)).

# Validation performed
<!-- What tests and validation you performed on the change -->
Limited validation performed so far since this change does not include support for decoding. Future commits should improve this.

We did generate IR streams using the support from this change and verified that it can be decoded using our closed-source IR stream decoders (written in other languages).