### PR TITLE
Use Ubuntu 20.04 (Focal) to build the native library for better compatibility on other Linux versions (fixes #24).

### DIFF
--- a/.github/workflows/build-and-release-package.yml
+++ b/.github/workflows/build-and-release-package.yml
@@ -28,7 +28,7 @@ jobs:
 
   build-package:
     needs: build-lib-for-macos
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -50,7 +50,7 @@ jobs:
 
   build-package:
     needs: build-lib-for-macos
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->
#24

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
v0.3 couldn't run on Ubuntu 20.04 and older because the build bound with newer glibc APIs that were available on Ubuntu 22.04 (where the release was built) but not on Ubuntu 20.04 and below.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Built the library using Ubuntu 20.04
* Verified that it could be used on Ubuntu 18.04, 20.04, and 22.04
* Ran the GitHub workflow on a fork and [verified](https://github.com/kirkrodrigues/clp-ffi-java/actions/runs/4290420022) all steps succeeded (except for publishing to GitHub)
