### PR TITLE
Static link libstdc++ to improve library compatibility on other Linux versions (fixes #28).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,3 +62,7 @@ target_include_directories(clp-ffi-java PRIVATE
 target_compile_options(clp-ffi-java PRIVATE
         "-D_REENTRANT"  # Necessary since the JVM is multithreaded
         )
+target_link_libraries(clp-ffi-java PRIVATE
+        # Static link to improve compatibility on other Linux versions
+        -static-libstdc++
+        )


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#28 

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
v0.3.2 couldn't run on Debian 8 because (as the issue identifies) the installed version doesn't support the required CXXABI version.

This PR simply static links libstdc++.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Built the JAR (& library) on Ubuntu Focal
* Installed it in Debian 8
* Verified that programs that use clp-ffi could run on Debian 8


