### PR TITLE
Add support for encoding wildcard queries into subqueries that can be used to search CLP-encoded messages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,9 @@ add_library(clp-ffi-java SHARED
         src/main/cpp/libclp_ffi_java/ir_stream/common.hpp
         src/main/cpp/libclp_ffi_java/ir_stream/common.tpp
         src/main/cpp/libclp_ffi_java/Java_AbstractClpIrOutputStream.cpp
+        src/main/cpp/libclp_ffi_java/Java_AbstractClpWildcardQueryEncoder.cpp
         src/main/cpp/libclp_ffi_java/Java_EightByteClpIrOutputStream.cpp
+        src/main/cpp/libclp_ffi_java/Java_EightByteClpWildcardQueryEncoder.cpp
         src/main/cpp/libclp_ffi_java/Java_FourByteClpIrOutputStream.cpp
         src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
         src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
@@ -39,12 +41,28 @@ add_library(clp-ffi-java SHARED
         src/main/cpp/libclp_ffi_java/JavaException.hpp
         src/main/cpp/libclp_ffi_java/JavaPrimitiveArrayElementsDeleter.cpp
         src/main/cpp/libclp_ffi_java/JavaPrimitiveArrayElementsDeleter.hpp
+        src/main/cpp/libclp_ffi_java/static_init.cpp
+        src/main/cpp/libclp_ffi_java/static_init.hpp
         src/main/cpp/submodules/clp/components/core/src/ffi/encoding_methods.cpp
         src/main/cpp/submodules/clp/components/core/src/ffi/encoding_methods.hpp
         src/main/cpp/submodules/clp/components/core/src/ffi/encoding_methods.tpp
         src/main/cpp/submodules/clp/components/core/src/ffi/ir_stream/encoding_methods.cpp
         src/main/cpp/submodules/clp/components/core/src/ffi/ir_stream/encoding_methods.hpp
         src/main/cpp/submodules/clp/components/core/src/ffi/ir_stream/protocol_constants.hpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/CompositeWildcardToken.cpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/CompositeWildcardToken.hpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/ExactVariableToken.cpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/ExactVariableToken.hpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/query_methods.cpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/query_methods.hpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/QueryMethodFailed.hpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/QueryToken.hpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/QueryWildcard.cpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/QueryWildcard.hpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/Subquery.cpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/Subquery.hpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/WildcardToken.cpp
+        src/main/cpp/submodules/clp/components/core/src/ffi/search/WildcardToken.hpp
         src/main/cpp/submodules/clp/components/core/src/string_utils.cpp
         src/main/cpp/submodules/clp/components/core/src/string_utils.hpp
         src/main/cpp/submodules/clp/components/core/src/string_utils.tpp

--- a/src/main/cpp/libclp_ffi_java/Java_AbstractClpWildcardQueryEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_AbstractClpWildcardQueryEncoder.cpp
@@ -1,0 +1,19 @@
+// JNI
+#include <com_yscope_clp_compressorfrontend_AbstractClpWildcardQueryEncoder.h>
+
+// Project headers
+#include "common.hpp"
+
+JNIEXPORT void JNICALL
+Java_com_yscope_clp_compressorfrontend_AbstractClpWildcardQueryEncoder_setVariableHandlingRuleVersions
+(
+        JNIEnv* jni_env,
+        jobject,
+        jbyteArray Java_variablesSchemaVersion,
+        jbyteArray Java_variableEncodingMethodsVersion
+) {
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
+    libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,
+                                                              Java_variableEncodingMethodsVersion);
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END()
+}

--- a/src/main/cpp/libclp_ffi_java/Java_EightByteClpWildcardQueryEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_EightByteClpWildcardQueryEncoder.cpp
@@ -212,7 +212,7 @@ static jobjectArray encode_native (
                                         "Failed to assign subquery to array in JVM");
         }
 
-        // Delete local references so we don't overwhelm the JVM
+        // Delete local references to avoid running out of memory in the JVM
         jni_env->DeleteLocalRef(Java_logtypeQuery);
         jni_env->DeleteLocalRef(Java_dictVarBounds);
         jni_env->DeleteLocalRef(Java_encodedVars);

--- a/src/main/cpp/libclp_ffi_java/Java_EightByteClpWildcardQueryEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_EightByteClpWildcardQueryEncoder.cpp
@@ -1,0 +1,225 @@
+// C++ standard libraries
+#include <string_view>
+#include <variant>
+#include <vector>
+
+// JNI
+#include <com_yscope_clp_compressorfrontend_EightByteClpWildcardQueryEncoder.h>
+
+// Project headers
+#include "../submodules/clp/components/core/src/ffi/encoding_methods.hpp"
+#include "../submodules/clp/components/core/src/ffi/search/ExactVariableToken.hpp"
+#include "../submodules/clp/components/core/src/ffi/search/query_methods.hpp"
+#include "../submodules/clp/components/core/src/ffi/search/QueryMethodFailed.hpp"
+#include "../submodules/clp/components/core/src/ffi/search/WildcardToken.hpp"
+#include "../submodules/clp/components/core/src/string_utils.hpp"
+#include "common.hpp"
+#include "GeneralException.hpp"
+#include "JavaException.hpp"
+#include "static_init.hpp"
+
+using ffi::eight_byte_encoded_variable_t;
+using ffi::search::ExactVariableToken;
+using ffi::search::Subquery;
+using ffi::search::WildcardToken;
+using libclp_ffi_java::GeneralException;
+using libclp_ffi_java::get_java_primitive_array_elements;
+using libclp_ffi_java::Java_EightByteClpEncodedSubQuery_init;
+using libclp_ffi_java::Java_EightByteClpEncodedSubQuery;
+using libclp_ffi_java::JavaExceptionOccurred;
+using libclp_ffi_java::JavaIllegalArgumentException;
+using libclp_ffi_java::JavaRuntimeException;
+using libclp_ffi_java::JavaUnsupportedOperationException;
+using libclp_ffi_java::new_java_primitive_array;
+using libclp_ffi_java::size_checked_pointer_cast;
+using std::string_view;
+using std::string;
+using std::variant;
+using std::vector;
+
+using EightByteExactVariableToken = ExactVariableToken<eight_byte_encoded_variable_t>;
+using EightByteWildcardToken = WildcardToken<eight_byte_encoded_variable_t>;
+
+// Local function prototypes
+/**
+ * See EightByteClpWildcardQueryEncoder::encodeNative in Java
+ * @param jni_env
+ * @param Java_wildcardQuery
+ * @param wildcard_query_length
+ * @return The encoded subqueries
+ */
+static jobjectArray encode_native (JNIEnv* jni_env, jbyteArray Java_wildcardQuery,
+                                   jint wildcard_query_length);
+
+JNIEXPORT jobjectArray JNICALL
+Java_com_yscope_clp_compressorfrontend_EightByteClpWildcardQueryEncoder_encodeNative (
+        JNIEnv* jni_env,
+        jobject,
+        jbyteArray Java_wildcardQuery,
+        jint wildcard_query_len
+) {
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
+    return encode_native(jni_env, Java_wildcardQuery, wildcard_query_len);
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(nullptr)
+}
+
+static jobjectArray encode_native (
+        JNIEnv* jni_env,
+        jbyteArray Java_wildcardQuery,
+        jint wildcard_query_length
+) {
+    // Get the message
+    auto wildcard_query_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
+            jni_env, Java_wildcardQuery, JNI_ABORT);
+    string_view wildcard_query{size_checked_pointer_cast<char>(wildcard_query_bytes.get()),
+                               static_cast<size_t>(wildcard_query_length)};
+
+    // Sanitize the wildcard query
+    auto clean_wildcard_query = clean_up_wildcard_search_string(wildcard_query);
+    auto Java_cleanWildcardQuery = new_java_primitive_array<jbyteArray>(
+            jni_env, size_checked_pointer_cast<jbyte>(clean_wildcard_query.data()),
+            clean_wildcard_query.size());
+
+    // Generate the subqueries
+    vector<Subquery<eight_byte_encoded_variable_t>> subqueries;
+    try {
+        ffi::search::generate_subqueries(clean_wildcard_query, subqueries);
+    } catch (const ffi::search::QueryMethodFailed& e) {
+        throw JavaIllegalArgumentException(__FILENAME__, __LINE__, jni_env, e.what());
+    }
+    if (subqueries.size() > libclp_ffi_java::cJSizeMax) {
+        throw JavaUnsupportedOperationException(__FILENAME__, __LINE__, jni_env,
+                                                "Subqueries can't fit in a Java array");
+    }
+    auto Java_subqueries = jni_env->NewObjectArray(static_cast<jsize>(subqueries.size()),
+                                                   Java_EightByteClpEncodedSubQuery, nullptr);
+    auto exception = jni_env->ExceptionOccurred();
+    if (nullptr != exception) {
+        throw JavaExceptionOccurred(ErrorCode_Failure, __FILENAME__, __LINE__,
+                                    "[native] Failed to allocate array in JVM for subqueries");
+    }
+    if (nullptr == Java_subqueries) {
+        throw GeneralException(ErrorCode_Failure, __FILENAME__, __LINE__,
+                               "[native] Failed to allocate array in JVM for subqueries");
+    }
+
+    vector<int32_t> dict_var_bounds;
+    vector<eight_byte_encoded_variable_t> encoded_vars;
+    vector<int8_t> wildcard_var_placeholders;
+    vector<int32_t> wildcard_var_bounds;
+    for (size_t i = 0; i < subqueries.size(); ++i) {
+        const auto& sub_query = subqueries[i];
+        const auto& logtype_query = sub_query.get_logtype_query();
+        const auto& query_vars = sub_query.get_query_vars();
+
+        // NOTE: Although the original query length is a jsize, the logtype
+        // length may be longer if the variable placeholders take up more space
+        // than the variables they replace. This doesn't happen at the time of
+        // writing, but it may in the future.
+        auto Java_logtypeQuery = new_java_primitive_array<jbyteArray, jbyte>(
+                jni_env, size_checked_pointer_cast<const jbyte>(logtype_query.data()),
+                logtype_query.length());
+
+        dict_var_bounds.clear();
+        encoded_vars.clear();
+        wildcard_var_placeholders.clear();
+        wildcard_var_bounds.clear();
+        for (const auto& query_var : query_vars) {
+            auto success = std::visit(overloaded{
+                    [&] (const EightByteExactVariableToken& var) {
+                        if (ffi::VariablePlaceholder::Dictionary == var.get_placeholder()) {
+                            // These static casts are safe since the original query
+                            // length is a jsize
+                            dict_var_bounds.push_back(
+                                    static_cast<int32_t>(var.get_begin_pos()));
+                            dict_var_bounds.push_back(
+                                    static_cast<int32_t>(var.get_end_pos()));
+                        } else {
+                            encoded_vars.push_back(var.get_encoded_value());
+                        }
+                        return true;
+                    },
+                    [&] (const EightByteWildcardToken& var) {
+                        switch (var.get_current_interpretation()) {
+                            case ffi::search::TokenType::IntegerVariable:
+                                wildcard_var_placeholders.push_back(
+                                        enum_to_underlying_type(
+                                                ffi::VariablePlaceholder::Integer));
+                                break;
+                            case ffi::search::TokenType::FloatVariable:
+                                wildcard_var_placeholders.push_back(
+                                        enum_to_underlying_type(
+                                                ffi::VariablePlaceholder::Float));
+                                break;
+                            case ffi::search::TokenType::DictionaryVariable:
+                                wildcard_var_placeholders.push_back(
+                                        enum_to_underlying_type(
+                                                ffi::VariablePlaceholder::Dictionary));
+                                break;
+                            default:
+                                // This should never happen
+                                return false;
+                        }
+                        // These static casts are safe since the original query
+                        // length is a jsize
+                        wildcard_var_bounds.push_back(
+                                static_cast<int32_t>(var.get_begin_pos()));
+                        wildcard_var_bounds.push_back(static_cast<int32_t>(var.get_end_pos()));
+                        return true;
+                    }
+            }, query_var);
+            if (false == success) {
+                throw JavaRuntimeException(__FILENAME__, __LINE__, jni_env,
+                        "[native] Unexpected exception when serializing subqueries.");
+            }
+        }
+
+        auto Java_dictVarBounds = new_java_primitive_array<jintArray, jint>(
+                jni_env, size_checked_pointer_cast<const jint>(dict_var_bounds.data()),
+                dict_var_bounds.size());
+
+        auto Java_encodedVars = new_java_primitive_array<jlongArray, jlong>(
+                jni_env, size_checked_pointer_cast<const jlong>(encoded_vars.data()),
+                encoded_vars.size());
+
+        auto Java_wildcardVarPlaceholders = new_java_primitive_array<jbyteArray, jbyte>(
+                jni_env,
+                size_checked_pointer_cast<const jbyte>(wildcard_var_placeholders.data()),
+                wildcard_var_placeholders.size());
+
+        auto Java_varWildcardQueryBounds = new_java_primitive_array<jintArray, jint>(
+                jni_env, size_checked_pointer_cast<const jint>(wildcard_var_bounds.data()),
+                wildcard_var_bounds.size());
+
+        auto Java_subquery = jni_env->NewObject(
+                Java_EightByteClpEncodedSubQuery, Java_EightByteClpEncodedSubQuery_init,
+                Java_cleanWildcardQuery, Java_logtypeQuery,
+                sub_query.logtype_query_contains_wildcards(), Java_dictVarBounds,
+                Java_encodedVars, Java_wildcardVarPlaceholders, Java_varWildcardQueryBounds);
+        exception = jni_env->ExceptionOccurred();
+        if (nullptr != exception) {
+            throw JavaExceptionOccurred(ErrorCode_Failure, __FILENAME__, __LINE__,
+                                        "[native] Failed to create subquery in JVM");
+        }
+        if (nullptr == Java_subquery) {
+            throw GeneralException(ErrorCode_Failure, __FILENAME__, __LINE__,
+                                   "[native] Failed to create subquery in JVM");
+        }
+        jni_env->SetObjectArrayElement(Java_subqueries, static_cast<jsize>(i), Java_subquery);
+        exception = jni_env->ExceptionOccurred();
+        if (nullptr != exception) {
+            throw JavaExceptionOccurred(ErrorCode_Failure, __FILENAME__, __LINE__,
+                                        "Failed to assign subquery to array in JVM");
+        }
+
+        // Delete local references so we don't overwhelm the JVM
+        jni_env->DeleteLocalRef(Java_logtypeQuery);
+        jni_env->DeleteLocalRef(Java_dictVarBounds);
+        jni_env->DeleteLocalRef(Java_encodedVars);
+        jni_env->DeleteLocalRef(Java_wildcardVarPlaceholders);
+        jni_env->DeleteLocalRef(Java_varWildcardQueryBounds);
+        jni_env->DeleteLocalRef(Java_subquery);
+    }
+
+    return Java_subqueries;
+}

--- a/src/main/cpp/libclp_ffi_java/common.cpp
+++ b/src/main/cpp/libclp_ffi_java/common.cpp
@@ -12,6 +12,21 @@ using ffi::cVariablesSchemaVersion;
 using std::string_view;
 
 namespace libclp_ffi_java {
+    jclass get_class_global_ref (JNIEnv* jni_env, const char* class_signature) {
+        auto local_class_ref = jni_env->FindClass(class_signature);
+        if (nullptr == local_class_ref) {
+            throw JavaClassNotFoundException(__FILENAME__, __LINE__, jni_env, class_signature);
+        }
+        auto global_class_ref = reinterpret_cast<jclass>(jni_env->NewGlobalRef(local_class_ref));
+        if (nullptr == global_class_ref) {
+            jni_env->DeleteLocalRef(local_class_ref);
+            throw JavaRuntimeException(__FILENAME__, __LINE__, jni_env, "NewGlobalRef failed");
+        }
+        jni_env->DeleteLocalRef(local_class_ref);
+
+        return global_class_ref;
+    }
+
     void validate_variable_handling_rule_versions (
             JNIEnv* jni_env,
             jbyteArray Java_variablesSchemaVersion,

--- a/src/main/cpp/libclp_ffi_java/common.hpp
+++ b/src/main/cpp/libclp_ffi_java/common.hpp
@@ -73,6 +73,15 @@ namespace libclp_ffi_java {
     }
 
     /**
+     * Gets a Java global reference (persists between JNI calls) to the Java
+     * class with the given signature
+     * @param jni_env
+     * @param class_signature
+     * @return The reference
+     */
+    jclass get_class_global_ref (JNIEnv* jni_env, const char* class_signature);
+
+    /**
      * Validates that the given version names for the variables schema and
      * variable encoding methods match the versions currently used by this
      * library.

--- a/src/main/cpp/libclp_ffi_java/static_init.cpp
+++ b/src/main/cpp/libclp_ffi_java/static_init.cpp
@@ -1,0 +1,103 @@
+#include "static_init.hpp"
+
+// JNI
+#include <jni.h>
+
+// Project headers
+#include "common.hpp"
+#include "JavaException.hpp"
+
+using libclp_ffi_java::Java_EncodedMessage;
+using libclp_ffi_java::Java_EightByteClpEncodedSubQuery;
+using libclp_ffi_java::Java_EightByteClpEncodedSubQuery_init;
+using libclp_ffi_java::Java_EncodedMessage_logtype;
+using libclp_ffi_java::Java_EncodedMessage_dictVarBounds;
+using libclp_ffi_java::Java_EncodedMessage_encodedVars;
+
+// Globals with external linkage
+namespace libclp_ffi_java {
+    jclass Java_EightByteClpEncodedSubQuery = nullptr;
+    jmethodID Java_EightByteClpEncodedSubQuery_init;
+    jclass Java_EncodedMessage = nullptr;
+    jfieldID Java_EncodedMessage_logtype;
+    jfieldID Java_EncodedMessage_dictVarBounds;
+    jfieldID Java_EncodedMessage_encodedVars;
+}
+
+// Constants
+static constexpr jint cRequiredJNIVersion = JNI_VERSION_1_6;
+
+// Local function prototypes
+/**
+ * Caches the field IDs for the Java EncodedMessage class
+ * @param jni_env
+ * @return true on success, false otherwise
+ */
+static bool cache_java_encoded_message_field_ids (JNIEnv* jni_env);
+
+static bool cache_java_encoded_message_field_ids (JNIEnv* jni_env) {
+    // NOTE: GetFieldID already throws Java exceptions, so we don't need to
+
+    // Get Java class fields and methods
+    Java_EightByteClpEncodedSubQuery_init = jni_env->GetMethodID(Java_EightByteClpEncodedSubQuery,
+                                                                 "<init>", "([B[BZ[I[J[B[I)V");
+    if (nullptr == Java_EightByteClpEncodedSubQuery_init) {
+        return false;
+    }
+    Java_EncodedMessage_logtype = jni_env->GetFieldID(Java_EncodedMessage, "logtype", "[B");
+    if (nullptr == Java_EncodedMessage_logtype) {
+        return false;
+    }
+    Java_EncodedMessage_encodedVars =
+            jni_env->GetFieldID(Java_EncodedMessage, "encodedVars", "[J");
+    if (nullptr == Java_EncodedMessage_encodedVars) {
+        return false;
+    }
+    Java_EncodedMessage_dictVarBounds =
+            jni_env->GetFieldID(Java_EncodedMessage, "dictionaryVarBounds", "[I");
+    if (nullptr == Java_EncodedMessage_dictVarBounds) {
+        return false;
+    }
+
+    return true;
+}
+
+JNIEXPORT jint JNICALL JNI_OnLoad (JavaVM* vm, void*) {
+    JNIEnv* jni_env;
+    // Based on the JDK 11 JNI docs, JNI 1.6 should be sufficient for all
+    // JNI methods except those related to modules
+    if (vm->GetEnv(reinterpret_cast<void**>(&jni_env), cRequiredJNIVersion) != JNI_OK) {
+        return JNI_ERR;
+    }
+
+    // Cache JNI objects
+    try {
+        Java_EightByteClpEncodedSubQuery = libclp_ffi_java::get_class_global_ref(
+                jni_env, "com/yscope/clp/compressorfrontend/EightByteClpEncodedSubquery");
+        Java_EncodedMessage = libclp_ffi_java::get_class_global_ref(
+                jni_env, "com/yscope/clp/compressorfrontend/EncodedMessage");
+    } catch (libclp_ffi_java::JavaException& e) {
+        return JNI_ERR;
+    }
+    if (cache_java_encoded_message_field_ids(jni_env) == false) {
+        jni_env->DeleteGlobalRef(Java_EightByteClpEncodedSubQuery);
+        jni_env->DeleteGlobalRef(Java_EncodedMessage);
+        Java_EncodedMessage = nullptr;
+        return JNI_ERR;
+    }
+
+    return cRequiredJNIVersion;
+}
+
+JNIEXPORT void JNICALL JNI_OnUnload (JavaVM* vm, void*) {
+    JNIEnv* jni_env;
+    if (vm->GetEnv(reinterpret_cast<void**>(&jni_env), cRequiredJNIVersion) != JNI_OK) {
+        // Unexpected error, but nothing we can do
+        return;
+    }
+
+    jni_env->DeleteGlobalRef(Java_EightByteClpEncodedSubQuery);
+    Java_EightByteClpEncodedSubQuery = nullptr;
+    jni_env->DeleteGlobalRef(Java_EncodedMessage);
+    Java_EncodedMessage = nullptr;
+}

--- a/src/main/cpp/libclp_ffi_java/static_init.hpp
+++ b/src/main/cpp/libclp_ffi_java/static_init.hpp
@@ -1,0 +1,15 @@
+#ifndef LIBCLP_FFI_JAVA_STATIC_INIT_HPP
+#define LIBCLP_FFI_JAVA_STATIC_INIT_HPP
+
+#include <jni.h>
+
+namespace libclp_ffi_java {
+    extern jclass Java_EightByteClpEncodedSubQuery;
+    extern jmethodID Java_EightByteClpEncodedSubQuery_init;
+    extern jclass Java_EncodedMessage;
+    extern jfieldID Java_EncodedMessage_logtype;
+    extern jfieldID Java_EncodedMessage_dictVarBounds;
+    extern jfieldID Java_EncodedMessage_encodedVars;
+}
+
+#endif //LIBCLP_FFI_JAVA_STATIC_INIT_HPP

--- a/src/main/java/com/yscope/clp/compressorfrontend/AbstractClpEncodedSubquery.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/AbstractClpEncodedSubquery.java
@@ -1,0 +1,195 @@
+package com.yscope.clp.compressorfrontend;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Base class representing a CLP-encoded subquery. Each subquery encompasses a
+ * single logtype query and zero or more variable queries. Both the logytpe
+ * and variables may contain these wildcards:
+ * <ul>
+ *   <li>'?' matching any single character</li>
+ *   <li>'*' matching 0 or more characters</li>
+ * </ul>
+ */
+public abstract class AbstractClpEncodedSubquery {
+  // NOTE: This must be kept in-sync with CLP's built-in variable schemas.
+  private static final byte VAR_SCHEMAS_V2_DICT_VAR_PLACEHOLDER = 0x12;
+
+  // For a description of these member variables, see the constructor.
+  private final byte[] query;
+  private final byte[] logtypeQuery;
+  private final boolean logtypeQueryContainsWildcards;
+  private final int[] dictVarBounds;
+  private final byte[] wildcardVarPlaceholders;
+  //
+  private final int[] wildcardVarBounds;
+
+  /**
+   * @param query The parent wildcard query for this subquery
+   * @param logtypeQuery The logtype query from encoding the parent query
+   * @param logtypeQueryContainsWildcards Whether logtypeQuery contains
+   * wildcards
+   * @param dictVarBounds The "begin" and "end" index of each dictionary
+   * variable, laid out as follows: [v1.begin, v1.end, v2.begin, v2.end, ...]
+   * This layout is more efficient to transfer across the JNI boundary.
+   * @param wildcardVarPlaceholders An array of placeholders, one for each
+   * variable (or potential variable) containing a wildcard, indicating how the
+   * variable query should be interpreted.
+   * @param wildcardVarBounds The "begin" and "end" index of each
+   * wildcard-containing variable, laid out as follows:
+   * [v1.begin, v1.end, v2.begin, v2.end, ...]. This layout is more efficient to
+   * transfer across the JNI boundary.
+   */
+  public AbstractClpEncodedSubquery (byte[] query, byte[] logtypeQuery,
+                                     boolean logtypeQueryContainsWildcards, int[] dictVarBounds,
+                                     byte[] wildcardVarPlaceholders, int[] wildcardVarBounds)
+  {
+    this.query = query;
+    this.logtypeQuery = logtypeQuery;
+    this.logtypeQueryContainsWildcards = logtypeQueryContainsWildcards;
+    this.dictVarBounds = dictVarBounds;
+    this.wildcardVarPlaceholders = wildcardVarPlaceholders;
+    this.wildcardVarBounds = wildcardVarBounds;
+  }
+
+  public String getLogtypeQueryAsString () {
+    return new String(logtypeQuery, StandardCharsets.ISO_8859_1);
+  }
+
+  public boolean logtypeQueryContainsWildcards () {
+    return logtypeQueryContainsWildcards;
+  }
+
+  /**
+   * @return An iterable of the dictionary variables as byte segments
+   */
+  public ByteSegments getDictVars () {
+    return new ByteSegments(query, dictVarBounds);
+  }
+
+  public int getNumDictVars () {
+    return dictVarBounds.length / 2;
+  }
+
+  /**
+   * @return An iterable of the wildcard-containing variables that should be
+   * interpreted as dictionary variables
+   */
+  public DictionaryVariableWildcardQueries getDictVarWildcardQueries () {
+    return new DictionaryVariableWildcardQueries();
+  }
+
+  public int getNumDictVarWildcardQueries () {
+    int count = 0;
+    for (VariableWildcardQuery ignored : getDictVarWildcardQueries()) {
+      ++count;
+    }
+    return count;
+  }
+
+  /**
+   * @return An iterable of the wildcard-containing variables that should be
+   * interpreted as encoded variables
+   */
+  public EncodedVariableWildcardQueries getEncodedVarWildcardQueries () {
+    return new EncodedVariableWildcardQueries();
+  }
+
+  public int getNumEncodedVarWildcardQueries () {
+    int count = 0;
+    for (VariableWildcardQuery ignored : getEncodedVarWildcardQueries()) {
+      ++count;
+    }
+    return count;
+  }
+
+  protected boolean containsVariables () {
+    return dictVarBounds.length > 0 || wildcardVarPlaceholders.length > 0;
+  }
+
+  /**
+   * Iterable class for the wildcard-containing variables that should be
+   * interpreted as dictionary variables
+   */
+  public class DictionaryVariableWildcardQueries extends VariableWildcardQueries {
+    @Override
+    public boolean isRelevantType (byte type) {
+      return VAR_SCHEMAS_V2_DICT_VAR_PLACEHOLDER == type;
+    }
+  }
+
+  /**
+   * Iterable class for the wildcard-containing variables that should be
+   * interpreted as encoded variables
+   */
+  public class EncodedVariableWildcardQueries extends VariableWildcardQueries {
+    @Override
+    public boolean isRelevantType (byte type) {
+      return VAR_SCHEMAS_V2_DICT_VAR_PLACEHOLDER != type;
+    }
+  }
+
+  /**
+   * Base iterable class for the wildcard-containing variables
+   */
+  public abstract class VariableWildcardQueries implements Iterable<VariableWildcardQuery> {
+    @Override
+    public Iterator iterator () {
+      return new Iterator();
+    }
+
+    public class Iterator implements java.util.Iterator<VariableWildcardQuery> {
+      private int substringBoundsIdx = 0;
+      private int varIdx = 0;
+
+      @Override
+      public boolean hasNext () {
+        while (varIdx < wildcardVarPlaceholders.length
+            && false == isRelevantType(wildcardVarPlaceholders[varIdx]))
+        {
+          ++varIdx;
+          substringBoundsIdx += 2;
+        }
+        return (wildcardVarPlaceholders.length != varIdx);
+      }
+
+      @Override
+      public VariableWildcardQuery next () {
+        int beginIdx = wildcardVarBounds[substringBoundsIdx++];
+        int endIdx = wildcardVarBounds[substringBoundsIdx++];
+        return new VariableWildcardQuery(wildcardVarPlaceholders[varIdx++],
+                                         new ByteSegment(query, beginIdx, endIdx));
+      }
+    }
+
+    /**
+     * @param type Type of the variable wildcard query
+     * @return Whether the type corresponds to variable queries relevant
+     * to this iterable
+     */
+    public abstract boolean isRelevantType (byte type);
+  }
+
+  /**
+   * A wildcard query for a variable with a certain type. Callers should not
+   * rely on the particular value of the type since it may change as the
+   * built-in schemas change.
+   */
+  public class VariableWildcardQuery {
+    private final byte type;
+    private final ByteSegment query;
+
+    public VariableWildcardQuery (byte type, ByteSegment query) {
+      this.type = type;
+      this.query = query;
+    }
+
+    public byte getType () {
+      return type;
+    }
+
+    public ByteSegment getQuery () {
+      return query;
+    }
+  }
+}

--- a/src/main/java/com/yscope/clp/compressorfrontend/AbstractClpWildcardQueryEncoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/AbstractClpWildcardQueryEncoder.java
@@ -1,0 +1,34 @@
+package com.yscope.clp.compressorfrontend;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Class to encode wildcard queries so that they can be used to search
+ * CLP-encoded messages.
+ */
+public abstract class AbstractClpWildcardQueryEncoder {
+  static {
+    NativeLibraryLoader.load();
+  }
+
+  /**
+   * @param variablesSchemaVersion The version of the variables schema to use to
+   *                               parse the query.
+   * @param variableEncodingMethodsVersion The version of variable encoding
+   *                                       methods to use to encode the query.
+   * @throws UnsupportedOperationException if either version was unknown or
+   * unsupported.
+   */
+  public AbstractClpWildcardQueryEncoder (
+      String variablesSchemaVersion,
+      String variableEncodingMethodsVersion
+  ) throws UnsupportedOperationException {
+    setVariableHandlingRuleVersions(variablesSchemaVersion.getBytes(StandardCharsets.ISO_8859_1),
+        variableEncodingMethodsVersion.getBytes(StandardCharsets.ISO_8859_1));
+  }
+
+  private native void setVariableHandlingRuleVersions (
+      byte[] variablesSchemaVersion,
+      byte[] variableEncodingMethodsVersion
+  ) throws UnsupportedOperationException;
+}

--- a/src/main/java/com/yscope/clp/compressorfrontend/ByteSegment.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/ByteSegment.java
@@ -1,0 +1,42 @@
+package com.yscope.clp.compressorfrontend;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * A view of part of a byte array, similar to {@link javax.swing.text.Segment}
+ */
+public class ByteSegment {
+  private final int beginIndex;
+  private final int endIndex;
+  private final byte[] parent;
+
+  /**
+   * @param parent The byte array backing this segment
+   * @param beginIndex The index of the first byte in this segment
+   * @param endIndex The index of the byte after the last byte in this segment
+   */
+  ByteSegment (byte[] parent, int beginIndex, int endIndex) {
+    this.parent = parent;
+    this.beginIndex = beginIndex;
+    this.endIndex = endIndex;
+  }
+
+  public int getBeginIndex() {
+    return beginIndex;
+  }
+
+  public int getEndIndex() {
+    return endIndex;
+  }
+
+  @Override
+  public String toString () {
+    return new String(parent, beginIndex, endIndex - beginIndex,
+        StandardCharsets.ISO_8859_1);
+  }
+
+  public byte[] toByteArray () {
+    return Arrays.copyOfRange(parent, beginIndex, endIndex);
+  }
+}

--- a/src/main/java/com/yscope/clp/compressorfrontend/ByteSegments.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/ByteSegments.java
@@ -1,0 +1,40 @@
+package com.yscope.clp.compressorfrontend;
+
+/**
+ * An iterable of byte segments
+ */
+public class ByteSegments implements Iterable<ByteSegment> {
+  protected final int[] segmentBounds;
+  private final byte[] parent;
+
+  /**
+   * @param parent The byte array backing all the iterable segments
+   * @param segmentBounds The bounds of all segments, laid out as follows:
+   * [s1.beginIndex, s1.endIndex, s2.beginIndex, s2.endIndex, ...].
+   */
+  public ByteSegments (byte[] parent, int[] segmentBounds) {
+    this.parent = parent;
+    this.segmentBounds = segmentBounds;
+  }
+
+  @Override
+  public Iterator iterator () {
+    return new Iterator();
+  }
+
+  public class Iterator implements java.util.Iterator<ByteSegment> {
+    protected int boundsIdx = 0;
+
+    @Override
+    public boolean hasNext() {
+      return boundsIdx < segmentBounds.length;
+    }
+
+    @Override
+    public ByteSegment next() {
+      int beginIdx = segmentBounds[boundsIdx++];
+      int endIdx = segmentBounds[boundsIdx++];
+      return new ByteSegment(parent, beginIdx, endIdx);
+    }
+  }
+}

--- a/src/main/java/com/yscope/clp/compressorfrontend/EightByteClpEncodedSubquery.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/EightByteClpEncodedSubquery.java
@@ -1,0 +1,27 @@
+package com.yscope.clp.compressorfrontend;
+
+/**
+ * A CLP-encoded subquery using the eight-byte encoding for variables.
+ */
+public class EightByteClpEncodedSubquery extends AbstractClpEncodedSubquery {
+  private final long[] encodedVars;
+
+  public EightByteClpEncodedSubquery (byte[] query, byte[] logtypeQuery,
+                                      boolean logtypeQueryContainsWildcards, int[] dictVarBounds,
+                                      long[] encodedVars, byte[] wildcardVarTypes,
+                                      int[] wildcardVarBounds)
+  {
+    super(query, logtypeQuery, logtypeQueryContainsWildcards, dictVarBounds, wildcardVarTypes,
+          wildcardVarBounds);
+    this.encodedVars = encodedVars;
+  }
+
+  @Override
+  public boolean containsVariables () {
+    return super.containsVariables() || encodedVars.length > 0;
+  }
+
+  public long[] getEncodedVars () {
+    return encodedVars;
+  }
+}

--- a/src/main/java/com/yscope/clp/compressorfrontend/EightByteClpWildcardQueryEncoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/EightByteClpWildcardQueryEncoder.java
@@ -1,0 +1,49 @@
+package com.yscope.clp.compressorfrontend;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Derived version of {@link AbstractClpWildcardQueryEncoder} specifically using
+ * the eight-byte encoding for variables.
+ */
+public class EightByteClpWildcardQueryEncoder extends AbstractClpWildcardQueryEncoder {
+  /**
+   * @see AbstractClpWildcardQueryEncoder#AbstractClpWildcardQueryEncoder
+   */
+  public EightByteClpWildcardQueryEncoder (
+      String variablesSchemaVersion,
+      String variableEncodingMethodsVersion
+  ) throws UnsupportedOperationException {
+    super(variablesSchemaVersion, variableEncodingMethodsVersion);
+  }
+
+  /**
+   * Encodes the given wildcard query into an array of subqueries that can be
+   * run on encoded messages. The array of subqueries is a logical disjunction
+   * (i.e., all subqueries OR-ed together).
+   * @param wildcardQuery The wildcard query using two wildcards:
+   * <ul>
+   *   <li>'?' matching any single character</li>
+   *   <li>'*' matching 0 or more characters</li>
+   * </ul>
+   * @return The subqueries
+   */
+  public EightByteClpEncodedSubquery[] encode (
+      String wildcardQuery
+  ) throws IllegalArgumentException {
+    byte[] wildcardQueryBytes = wildcardQuery.getBytes(StandardCharsets.ISO_8859_1);
+    return encodeNative(wildcardQueryBytes, wildcardQueryBytes.length);
+  }
+
+  /**
+   * Same as {@link EightByteClpWildcardQueryEncoder#encode} except
+   * {@code wildcardQuery} is a byte array.
+   * @param wildcardQuery
+   * @param wildcardQueryLength
+   * @return The subqueries
+   */
+  private native EightByteClpEncodedSubquery[] encodeNative (
+      byte[] wildcardQuery,
+      int wildcardQueryLength
+  ) throws IllegalArgumentException;
+}

--- a/src/main/java/com/yscope/clp/compressorfrontend/MessageDecoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/MessageDecoder.java
@@ -127,12 +127,28 @@ public class MessageDecoder {
 
   /**
    * For each log message in a batch of messages, checks whether the given
-   * wildcard queries match the message's encoded variables. Specifically, let
-   * {w in W} be the set of wildcard strings and {e in E} be the set of encoded
-   * variables. This method will return true only if:
+   * wildcard queries for variables match the message's encoded variables.
+   * <br>
+   * For example, consider a user's wildcard query, "*123*456*789*". One
+   * potential CLP subquery might have this original wildcard query decomposed
+   * into three wildcard queries for three encoded variables: ["*123*", "*456*",
+   * "*789*"]. We refer to these decomposed wildcard queries as variable
+   * wildcard-queries. Consider matching these variable wildcard-queries against
+   * a message with these encoded variables: [123, 0, 456, 0, 789]. This method
+   * should return true since each of the variable wildcard-queries matches a
+   * unique encoded variable, in sequence.
+   * <br>
+   * Specifically, let {w in W} be the set of variable wildcard-queries and
+   * {e in E} be the set of encoded variables. This method will return true if
+   * and only if:
    * (1) Each unique `w` matches a unique `e`.
    * (2) When (1) is true, the order of elements in both W and E is unchanged.
-   * NOTE: Instead of taking an array of objects, this method takes arrays of
+   * <br>
+   * NOTE 1: This is just one part of CLP's query processing algorithm. For more
+   * details, see
+   * https://github.com/y-scope/clp/blob/main/components/core/src/ffi/search/README.md
+   * <br>
+   * NOTE 2: Instead of taking an array of objects, this method takes arrays of
    * object-members (the result of serializing the objects) since this is
    * currently called from contexts where the objects will have already been
    * serialized.

--- a/src/test/java/com/yscope/clp/compressorfrontend/EncodingTests.java
+++ b/src/test/java/com/yscope/clp/compressorfrontend/EncodingTests.java
@@ -1,9 +1,10 @@
 package com.yscope.clp.compressorfrontend;
 
-import org.junit.jupiter.api.Test;
-
+import com.yscope.clp.compressorfrontend.AbstractClpEncodedSubquery.VariableWildcardQuery;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -40,5 +41,153 @@ public class EncodingTests {
     } catch (IOException e) {
       fail(e.getMessage());
     }
+  }
+
+  @Test
+  void test() {
+    EightByteClpWildcardQueryEncoder encoder = new EightByteClpWildcardQueryEncoder(
+        BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
+        BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1
+    );
+
+    // Validate encoding a message as a query
+    String query = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
+    EightByteClpEncodedSubquery[] subqueries = encoder.encode(query);
+    assertEquals(1, subqueries.length);
+    EightByteClpEncodedSubquery subquery = subqueries[0];
+    assertTrue(subquery.containsVariables());
+    assertFalse(subquery.logtypeQueryContainsWildcards());
+    assertFalse(subquery.getDictVarWildcardQueries().iterator().hasNext());
+    assertFalse(subquery.getEncodedVarWildcardQueries().iterator().hasNext());
+
+    // Validate that the query can be decoded correctly
+    MessageDecoder messageDecoder =
+        new MessageDecoder(BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
+            BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
+    String decodedQuery;
+    try {
+      String logtypeQuery = subquery.getLogtypeQueryAsString();
+      String[] dictVars = new String[subquery.getNumDictVars()];
+      int i = 0;
+      for (ByteSegment s : subquery.getDictVars()) {
+        dictVars[i++] = s.toString();
+      }
+      long[] encodedVars = subquery.getEncodedVars();
+      decodedQuery = messageDecoder.decodeMessage(logtypeQuery, dictVars, encodedVars);
+    } catch (Exception e) {
+      fail("Failed to decode encoded query", e);
+      // We'll never execute this return, but it's necessary for static analysis
+      // to pass
+      return;
+    }
+    assertEquals(query, decodedQuery);
+
+    // Validate encoding a query with wildcards
+    String wildcardQuery = "*123*";
+    subqueries = encoder.encode(wildcardQuery);
+    // Based on our current built-in schemas, this should generate at least two
+    // subqueries: one for a dictionary variable and one for a non-dictionary
+    // variable
+    assertTrue(subqueries.length > 1);
+
+    for (EightByteClpEncodedSubquery s : subqueries) {
+      assertTrue(s.containsVariables());
+      assertTrue(s.logtypeQueryContainsWildcards());
+      // Each subquery should have at least one wildcard variable, but not
+      // both a dictionary variable and an encoded variable
+      assertTrue((s.getNumDictVarWildcardQueries() > 0)
+                     ^ (s.getNumEncodedVarWildcardQueries() > 0));
+    }
+
+    // Validate error for an empty query
+    assertThrows(IllegalArgumentException.class, () -> encoder.encode(""));
+
+    // TODO Add some more tests
+  }
+
+  @Test
+  void testBatchEncodedVarsWildcardMatchNative() {
+    MessageEncoder messageEncoder = new MessageEncoder(
+        BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
+        BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
+    EncodedMessage encodedMessage = new EncodedMessage();
+
+    // Encode some messages
+    final int numMessages = 3;
+    byte[][] logtypes = new byte[numMessages][];
+    long[][] encodedVarArrays = new long[numMessages][];
+    try {
+      int msgIdx = 0;
+      messageEncoder.encodeMessage("Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3",
+          encodedMessage);
+      logtypes[msgIdx] = encodedMessage.logtype;
+      encodedVarArrays[msgIdx] = encodedMessage.encodedVars;
+      ++msgIdx;
+
+      messageEncoder.encodeMessage("Message with only static text.", encodedMessage);
+      logtypes[msgIdx] = encodedMessage.logtype;
+      encodedVarArrays[msgIdx] = encodedMessage.encodedVars;
+      ++msgIdx;
+
+      messageEncoder.encodeMessage("Message with 1 + 1 encoded variables.", encodedMessage);
+      logtypes[msgIdx] = encodedMessage.logtype;
+      encodedVarArrays[msgIdx] = encodedMessage.encodedVars;
+    } catch (IOException e) {
+      fail("Failed to encode messages", e);
+    }
+
+    // Encode a query
+    EightByteClpWildcardQueryEncoder queryEncoder = new EightByteClpWildcardQueryEncoder(
+        BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
+        BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1
+    );
+    EightByteClpEncodedSubquery[] subqueries = queryEncoder.encode("*1* *987*");
+
+    // Match the messages against the subqueries
+    int[] matchingRows = new int[numMessages];
+    try {
+      MessageDecoder messageDecoder = new MessageDecoder(
+          BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
+          BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
+
+      for (EightByteClpEncodedSubquery subquery : subqueries) {
+        // Prepare arguments for batchEncodedVarsWildcardMatch
+        int numEncodedVarWildcardQueries = subquery.getNumEncodedVarWildcardQueries();
+        byte[] encodedVarWildcardTypes = new byte[numEncodedVarWildcardQueries];
+        int[] encodedVarWildcardQueryEndIndexes = new int[numEncodedVarWildcardQueries];
+        ByteArrayOutputStream serializedEncodedVarWildcardQueries = new ByteArrayOutputStream();
+        int wildcardEncodedVarIdx = 0;
+        for (VariableWildcardQuery q : subquery.getEncodedVarWildcardQueries()) {
+          encodedVarWildcardTypes[wildcardEncodedVarIdx] = q.getType();
+          serializedEncodedVarWildcardQueries.write(q.getQuery().toByteArray());
+          encodedVarWildcardQueryEndIndexes[wildcardEncodedVarIdx] =
+              serializedEncodedVarWildcardQueries.size();
+
+          ++wildcardEncodedVarIdx;
+        }
+        int[] matchResults = new int[logtypes.length];
+
+        messageDecoder.batchEncodedVarsWildcardMatch(
+            logtypes,
+            encodedVarArrays,
+            encodedVarWildcardTypes,
+            serializedEncodedVarWildcardQueries.toByteArray(),
+            encodedVarWildcardQueryEndIndexes,
+            matchResults);
+        for (int i = 0; i < matchingRows.length; ++i) {
+          matchingRows[i] += matchResults[i];
+        }
+      }
+    } catch (Exception e) {
+      fail(e.getMessage(), e);
+    }
+
+    int rowIdx = 0;
+    // First row should've matched at least one subquery
+    assertTrue(matchingRows[rowIdx++] > 0);
+    // Second row shouldn't match any subquery
+    assertEquals(0, matchingRows[rowIdx++]);
+    // Third row should've matched at least one subquery
+    assertTrue(matchingRows[rowIdx++] > 0);
   }
 }

--- a/src/test/java/com/yscope/clp/compressorfrontend/EncodingTests.java
+++ b/src/test/java/com/yscope/clp/compressorfrontend/EncodingTests.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class EncodingTests {
   @Test
-  void testEncodings() {
+  void testEncodingMessages () {
     try {
       String message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
       EncodedMessage encodedMessage = new EncodedMessage();
@@ -44,7 +44,7 @@ public class EncodingTests {
   }
 
   @Test
-  void test() {
+  void testEncodingQueries () {
     EightByteClpWildcardQueryEncoder encoder = new EightByteClpWildcardQueryEncoder(
         BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
         BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1
@@ -63,7 +63,7 @@ public class EncodingTests {
     // Validate that the query can be decoded correctly
     MessageDecoder messageDecoder =
         new MessageDecoder(BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
-            BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
+                           BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
     String decodedQuery;
     try {
       String logtypeQuery = subquery.getLogtypeQueryAsString();
@@ -106,7 +106,7 @@ public class EncodingTests {
   }
 
   @Test
-  void testBatchEncodedVarsWildcardMatchNative() {
+  void testBatchEncodedVarsWildcardMatchNative () {
     MessageEncoder messageEncoder = new MessageEncoder(
         BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
         BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
@@ -119,7 +119,7 @@ public class EncodingTests {
     try {
       int msgIdx = 0;
       messageEncoder.encodeMessage("Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3",
-          encodedMessage);
+                                   encodedMessage);
       logtypes[msgIdx] = encodedMessage.logtype;
       encodedVarArrays[msgIdx] = encodedMessage.encodedVars;
       ++msgIdx;


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR exposes CLP's methods for encoding wildcard queries into subqueries that can be used to search CLP-encoded messages. For instance, we can use the subqueries and query methods to search for CLP-encoded messages stored in [Apache Pinot](https://github.com/apache/pinot).

Note that this PR doesn't handle query encoding for the four-byte encoding for variables. This will be added in a future commit.

# Validation performed
<!-- What tests and validation you performed on the change -->
Validated old and new tests pass.
