### PR TITLE
Wrap all JNI method bodies to ensure C++ exceptions don't crash the JVM; Add better error handling for JNI methods.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(clp-ffi-java SHARED
         src/main/cpp/libclp_ffi_java/ClpIrOutputStreamState.hpp
         src/main/cpp/libclp_ffi_java/common.cpp
         src/main/cpp/libclp_ffi_java/common.hpp
+        src/main/cpp/libclp_ffi_java/common.tpp
+        src/main/cpp/libclp_ffi_java/GeneralException.hpp
         src/main/cpp/libclp_ffi_java/ir_stream/common.hpp
         src/main/cpp/libclp_ffi_java/ir_stream/common.tpp
         src/main/cpp/libclp_ffi_java/Java_AbstractClpIrOutputStream.cpp

--- a/src/main/cpp/libclp_ffi_java/GeneralException.hpp
+++ b/src/main/cpp/libclp_ffi_java/GeneralException.hpp
@@ -1,0 +1,85 @@
+#ifndef LIBCLP_FFI_JAVA_OPERATIONEXCEPTION_HPP
+#define LIBCLP_FFI_JAVA_OPERATIONEXCEPTION_HPP
+
+// C++ standard libraries
+#include <string>
+
+// Project headers
+#include "../submodules/clp/components/core/src/TraceableException.hpp"
+#include "JavaException.hpp"
+
+namespace libclp_ffi_java {
+    class GeneralException : public TraceableException {
+    public:
+        /**
+         * @param error_code
+         * @param filename
+         * @param line_number
+         * @param message
+         */
+        GeneralException (
+                ErrorCode error_code,
+                const char* filename,
+                int line_number,
+                std::string message
+        ) : TraceableException(error_code, filename, line_number), m_message(std::move(message)) {}
+
+        [[nodiscard]] const char* what () const noexcept override {
+            return m_message.c_str();
+        }
+
+    private:
+        std::string m_message;
+    };
+
+    /**
+     * An exception after a Java exception has already occurred. This is useful
+     * so that we can differentiate between exceptions where we should propagate
+     * the error to Java and exceptions where we should *not* because an
+     * exception is already pending in Java.
+     */
+    class JavaExceptionOccurred : public GeneralException {
+    public:
+        /**
+         * @param error_code
+         * @param filename
+         * @param line_number
+         * @param message
+         */
+        JavaExceptionOccurred (
+                ErrorCode error_code,
+                const char* filename,
+                int line_number,
+                std::string message
+        ) : GeneralException(error_code, filename, line_number, std::move(message)) {}
+    };
+} // libclp_ffi_java
+
+/**
+ * Begins a try block
+ * @param ignore Parameter so the macro call looks like a function invocation.
+ */
+#define LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN(ignore) try {
+/**
+ * Ends a try block and handles all exceptions. If an exception has already
+ * been thrown in Java, this block will simply return. If not, an exception
+ * will be thrown in Java before returning.
+ * @param ERROR_RETURN_VAL The value to return on error
+ */
+#define LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(ERROR_RETURN_VAL) \
+        } catch (libclp_ffi_java::JavaException& e) { \
+            /* Corresponding exception already thrown in Java */ \
+            return ERROR_RETURN_VAL; \
+        } catch (libclp_ffi_java::JavaExceptionOccurred& e) { \
+            /* An exception was already thrown in Java, so we shouldn't */ \
+            /* throw another */ \
+            return ERROR_RETURN_VAL; \
+        } catch (std::exception& e) { \
+            libclp_ffi_java::JavaRuntimeException::throw_in_java(jni_env, e.what()); \
+            return ERROR_RETURN_VAL; \
+        } catch (...) { \
+            libclp_ffi_java::JavaRuntimeException::throw_in_java(jni_env, \
+                                                                 "[native] Unexpected exception"); \
+            return ERROR_RETURN_VAL; \
+        }
+#endif //LIBCLP_FFI_JAVA_OPERATIONEXCEPTION_HPP

--- a/src/main/cpp/libclp_ffi_java/JavaException.cpp
+++ b/src/main/cpp/libclp_ffi_java/JavaException.cpp
@@ -2,6 +2,8 @@
 
 // Constants
 static constexpr char cJavaClassNotFoundExceptionSignature[] = "java/lang/ClassNotFoundException";
+static constexpr char cJavaIllegalArgumentExceptionSignature[] =
+        "java/lang/IllegalArgumentException";
 static constexpr char cJavaIOExceptionSignature[] = "java/io/IOException";
 static constexpr char cJavaRuntimeExceptionSignature[] = "java/lang/RuntimeException";
 static constexpr char cJavaUnsupportedOperationException[] =
@@ -43,6 +45,18 @@ namespace libclp_ffi_java {
     void JavaClassNotFoundException::throw_in_java (JNIEnv* jni_env, const char* class_name) {
         JavaException::throw_in_java(jni_env, cJavaClassNotFoundExceptionSignature,
                                      string("Couldn't find ") + class_name);
+    }
+
+    JavaIllegalArgumentException::JavaIllegalArgumentException (
+            const char* filename,
+            int line_number,
+            JNIEnv* jni_env,
+            const string& message
+    ) : JavaException(ErrorCode_Failure, filename, line_number, jni_env,
+                      cJavaIllegalArgumentExceptionSignature, message) {}
+
+    void JavaIllegalArgumentException::throw_in_java (JNIEnv* jni_env, const string& message) {
+        JavaException::throw_in_java(jni_env, cJavaIllegalArgumentExceptionSignature, message);
     }
 
     JavaIOException::JavaIOException (const char* filename, int line_number,

--- a/src/main/cpp/libclp_ffi_java/JavaException.hpp
+++ b/src/main/cpp/libclp_ffi_java/JavaException.hpp
@@ -82,6 +82,16 @@ namespace libclp_ffi_java {
         static void throw_in_java (JNIEnv* jni_env, const char* class_name);
     };
 
+    class JavaIllegalArgumentException : public JavaException {
+    public:
+        // Constructors
+        JavaIllegalArgumentException (const char* filename, int line_number, JNIEnv* jni_env,
+                                      const std::string& message);
+
+        // Methods
+        static void throw_in_java (JNIEnv* jni_env, const std::string& message);
+    };
+
     class JavaIOException : public JavaException {
     public:
         // Constructors

--- a/src/main/cpp/libclp_ffi_java/Java_AbstractClpIrOutputStream.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_AbstractClpIrOutputStream.cpp
@@ -7,15 +7,19 @@
 
 // Project headers
 #include "ClpIrOutputStreamState.hpp"
+#include "GeneralException.hpp"
 
 using libclp_ffi_java::ClpIrOutputStreamState;
 
 JNIEXPORT jlong JNICALL
-Java_com_yscope_clp_irstream_AbstractClpIrOutputStream_createNativeState (JNIEnv*, jobject) {
+Java_com_yscope_clp_irstream_AbstractClpIrOutputStream_createNativeState (JNIEnv* jni_env, jobject)
+{
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     // NOTE: The use of uintptr_t means that if for some reason,
     // sizeof(jlong) < sizeof(void*) but sizeof(jlong) == sizeof(uintptr_t),
     // then this conversion will still work.
-    return bit_cast<jlong>(reinterpret_cast<uintptr_t>(new(std::nothrow) ClpIrOutputStreamState()));
+    return bit_cast<jlong>(reinterpret_cast<uintptr_t>(new ClpIrOutputStreamState()));
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(0)
 }
 
 JNIEXPORT void JNICALL

--- a/src/main/cpp/libclp_ffi_java/Java_AbstractClpIrOutputStream.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_AbstractClpIrOutputStream.cpp
@@ -15,7 +15,7 @@ Java_com_yscope_clp_irstream_AbstractClpIrOutputStream_createNativeState (JNIEnv
     // NOTE: The use of uintptr_t means that if for some reason,
     // sizeof(jlong) < sizeof(void*) but sizeof(jlong) == sizeof(uintptr_t),
     // then this conversion will still work.
-    return bit_cast<jlong>(reinterpret_cast<uintptr_t>(new ClpIrOutputStreamState()));
+    return bit_cast<jlong>(reinterpret_cast<uintptr_t>(new(std::nothrow) ClpIrOutputStreamState()));
 }
 
 JNIEXPORT void JNICALL

--- a/src/main/cpp/libclp_ffi_java/Java_EightByteClpIrOutputStream.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_EightByteClpIrOutputStream.cpp
@@ -1,28 +1,15 @@
-// C++ standard libraries
-#include <string_view>
-
 // CLP
 #include "../submodules/clp/components/core/src/ffi/ir_stream/encoding_methods.hpp"
-#include "../submodules/clp/components/core/src/type_utils.hpp"
 
 // JNI
 #include <com_yscope_clp_irstream_EightByteClpIrOutputStream.h>
 
 // Project headers
-#include "ClpIrOutputStreamState.hpp"
-#include "common.hpp"
+#include "GeneralException.hpp"
 #include "ir_stream/common.hpp"
-#include "JavaException.hpp"
 
-using ffi::ir_stream::eight_byte_encoding::encode_message;
-using ffi::ir_stream::eight_byte_encoding::encode_preamble;
-using libclp_ffi_java::cJSizeMax;
-using libclp_ffi_java::ClpIrOutputStreamState;
 using libclp_ffi_java::ir_stream::encode_log_event;
-using libclp_ffi_java::JavaIOException;
-using libclp_ffi_java::JavaRuntimeException;
-using libclp_ffi_java::size_checked_pointer_cast;
-using std::string_view;
+using libclp_ffi_java::ir_stream::encode_preamble;
 
 JNIEXPORT jbyteArray JNICALL
 Java_com_yscope_clp_irstream_EightByteClpIrOutputStream_encodePreambleNative (
@@ -36,7 +23,8 @@ Java_com_yscope_clp_irstream_EightByteClpIrOutputStream_encodePreambleNative (
         jbyteArray Java_timeZoneId,
         jint time_zone_id_length
 ) {
-    return libclp_ffi_java::ir_stream::encode_preamble<ffi::eight_byte_encoded_variable_t>(
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
+    return encode_preamble<ffi::eight_byte_encoded_variable_t>(
             jni_env,
             stream_state_address,
             Java_timestampPattern,
@@ -47,6 +35,7 @@ Java_com_yscope_clp_irstream_EightByteClpIrOutputStream_encodePreambleNative (
             time_zone_id_length,
             0
     );
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(nullptr)
 }
 
 JNIEXPORT jbyteArray JNICALL
@@ -58,6 +47,8 @@ Java_com_yscope_clp_irstream_EightByteClpIrOutputStream_encodeLogEventNative (
         jbyteArray Java_message,
         jint message_length
 ) {
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     return encode_log_event<ffi::eight_byte_encoded_variable_t>(
             jni_env, stream_state_address, timestamp, Java_message, message_length);
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(nullptr)
 }

--- a/src/main/cpp/libclp_ffi_java/Java_FourByteClpIrOutputStream.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_FourByteClpIrOutputStream.cpp
@@ -1,28 +1,15 @@
-// C++ standard libraries
-#include <string_view>
-
 // CLP
 #include "../submodules/clp/components/core/src/ffi/ir_stream/encoding_methods.hpp"
-#include "../submodules/clp/components/core/src/type_utils.hpp"
 
 // JNI
 #include <com_yscope_clp_irstream_FourByteClpIrOutputStream.h>
 
 // Project headers
-#include "ClpIrOutputStreamState.hpp"
-#include "common.hpp"
+#include "GeneralException.hpp"
 #include "ir_stream/common.hpp"
-#include "JavaException.hpp"
 
-using ffi::ir_stream::four_byte_encoding::encode_message;
-using ffi::ir_stream::four_byte_encoding::encode_preamble;
-using libclp_ffi_java::cJSizeMax;
-using libclp_ffi_java::ClpIrOutputStreamState;
 using libclp_ffi_java::ir_stream::encode_log_event;
-using libclp_ffi_java::JavaIOException;
-using libclp_ffi_java::JavaRuntimeException;
-using libclp_ffi_java::size_checked_pointer_cast;
-using std::string_view;
+using libclp_ffi_java::ir_stream::encode_preamble;
 
 JNIEXPORT jbyteArray JNICALL
 Java_com_yscope_clp_irstream_FourByteClpIrOutputStream_encodePreambleNative (
@@ -37,7 +24,8 @@ Java_com_yscope_clp_irstream_FourByteClpIrOutputStream_encodePreambleNative (
         jint time_zone_id_length,
         jlong reference_timestamp
 ) {
-    return libclp_ffi_java::ir_stream::encode_preamble<ffi::four_byte_encoded_variable_t>(
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
+    return encode_preamble<ffi::four_byte_encoded_variable_t>(
             jni_env,
             stream_state_address,
             Java_timestampPattern,
@@ -48,6 +36,7 @@ Java_com_yscope_clp_irstream_FourByteClpIrOutputStream_encodePreambleNative (
             time_zone_id_length,
             reference_timestamp
     );
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(nullptr)
 }
 
 JNIEXPORT jbyteArray JNICALL
@@ -59,9 +48,11 @@ Java_com_yscope_clp_irstream_FourByteClpIrOutputStream_encodeLogEventNative (
         jbyteArray Java_message,
         jint message_length
 ) {
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     // NOTE: Although encode_log_event takes `timestamp` as a parameter rather
     // than `timestamp_delta`, they are the same type and encode_log_event just
     // passes it through
     return encode_log_event<ffi::four_byte_encoded_variable_t>(
             jni_env, stream_state_address, timestamp_delta, Java_message, message_length);
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(nullptr)
 }

--- a/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
@@ -23,6 +23,21 @@ using libclp_ffi_java::JavaIOException;
 using libclp_ffi_java::size_checked_pointer_cast;
 using std::string_view;
 
+// Local function prototypes
+/**
+ * See MessageDecoder::decodeMessageNative in Java
+ * @param jni_env
+ * @param Java_logtype
+ * @param Java_allDictionaryVars
+ * @param Java_dictionaryVarEndOffsets
+ * @param Java_encodedVars
+ * @return The decoded message
+ */
+static jbyteArray decode_message_native (JNIEnv* jni_env, jbyteArray Java_logtype,
+                                         jbyteArray Java_allDictionaryVars,
+                                         jintArray Java_dictionaryVarEndOffsets,
+                                         jlongArray Java_encodedVars);
+
 /**
  * Wrapper around wildcard_query_matches_any_encoded_var which
  * @tparam var_placeholder
@@ -30,33 +45,27 @@ using std::string_view;
  * @param Java_wildcard_query
  * @param Java_logtype
  * @param Java_encoded_vars
- * @return
+ * @return true if a match was found, false otherwise
  */
 template <VariablePlaceholder var_placeholder>
-bool jni_wildcard_query_matches_any_encoded_var (JNIEnv* jni_env, jbyteArray Java_wildcard_query,
-                                                 jbyteArray Java_logtype,
-                                                 jlongArray Java_encoded_vars);
+static bool jni_wildcard_query_matches_any_encoded_var (
+        JNIEnv* jni_env, jbyteArray Java_wildcard_query, jbyteArray Java_logtype,
+        jlongArray Java_encoded_vars);
 
 template <VariablePlaceholder var_placeholder>
-bool jni_wildcard_query_matches_any_encoded_var (JNIEnv* jni_env, jbyteArray Java_wildcard_query,
-                                                 jbyteArray Java_logtype,
-                                                 jlongArray Java_encoded_vars)
+static bool jni_wildcard_query_matches_any_encoded_var (
+        JNIEnv* jni_env, jbyteArray Java_wildcard_query, jbyteArray Java_logtype,
+        jlongArray Java_encoded_vars)
 {
     // Get logtype
     auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
             jni_env, Java_logtype, JNI_ABORT);
-    if (nullptr == logtype_bytes) {
-        return false;
-    }
     auto logtype_length = jni_env->GetArrayLength(Java_logtype);
     string_view logtype(size_checked_pointer_cast<char>(logtype_bytes.get()), logtype_length);
 
     // Get wildcard query
     auto wildcard_query_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
             jni_env, Java_wildcard_query, JNI_ABORT);
-    if (nullptr == wildcard_query_bytes) {
-        return false;
-    }
     auto wildcard_query_length = jni_env->GetArrayLength(Java_wildcard_query);
     string_view wildcard_query(size_checked_pointer_cast<char>(wildcard_query_bytes.get()),
                                wildcard_query_length);
@@ -64,9 +73,6 @@ bool jni_wildcard_query_matches_any_encoded_var (JNIEnv* jni_env, jbyteArray Jav
     // Get encoded variables
     auto encoded_vars = get_java_primitive_array_elements<jlongArray, jlong>(
             jni_env, Java_encoded_vars, JNI_ABORT);
-    if (nullptr == encoded_vars) {
-        return false;
-    }
     auto encoded_vars_length = jni_env->GetArrayLength(Java_encoded_vars);
 
     try {
@@ -76,8 +82,7 @@ bool jni_wildcard_query_matches_any_encoded_var (JNIEnv* jni_env, jbyteArray Jav
                 encoded_vars_length
         );
     } catch (const ffi::EncodingException& e) {
-        JavaIOException::throw_in_java(jni_env, e.what());
-        return false;
+        throw JavaIOException(__FILENAME__, __LINE__, jni_env, e.what());
     }
 }
 
@@ -88,8 +93,10 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_setVariableHandlingRuleVer
         jbyteArray Java_variablesSchemaVersion,
         jbyteArray Java_variableEncodingMethodsVersion
 ) {
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,
                                                               Java_variableEncodingMethodsVersion);
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END()
 }
 
 JNIEXPORT jbyteArray JNICALL
@@ -101,66 +108,10 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
         jintArray Java_dictionaryVarEndOffsets,
         jlongArray Java_encodedVars
 ) {
-    // Get logtype
-    auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
-            jni_env, Java_logtype, JNI_ABORT);
-    if (nullptr == logtype_bytes) {
-        return nullptr;
-    }
-    auto logtype_length = jni_env->GetArrayLength(Java_logtype);
-    string_view logtype(size_checked_pointer_cast<char>(logtype_bytes.get()), logtype_length);
-
-    // Get dictionary variables
-    auto all_dictionary_vars_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
-            jni_env, Java_allDictionaryVars, JNI_ABORT);
-    if (nullptr == all_dictionary_vars_bytes) {
-        return nullptr;
-    }
-    auto all_dictionary_vars_length = jni_env->GetArrayLength(Java_allDictionaryVars);
-    string_view all_dictionary_vars(
-            size_checked_pointer_cast<char>(all_dictionary_vars_bytes.get()),
-            all_dictionary_vars_length);
-
-    auto dictionary_var_end_offsets = get_java_primitive_array_elements<jintArray, jint>(
-            jni_env, Java_dictionaryVarEndOffsets, JNI_ABORT);
-    if (nullptr == dictionary_var_end_offsets) {
-        return nullptr;
-    }
-    auto dictionary_var_end_offsets_length = jni_env->GetArrayLength(Java_dictionaryVarEndOffsets);
-
-    // Get encoded variables
-    auto encoded_vars = get_java_primitive_array_elements<jlongArray, jlong>(
-            jni_env, Java_encodedVars, JNI_ABORT);
-    if (nullptr == encoded_vars) {
-        return nullptr;
-    }
-    auto encoded_vars_length = jni_env->GetArrayLength(Java_encodedVars);
-
-    try {
-        auto message = decode_message(
-                logtype,
-                size_checked_pointer_cast<eight_byte_encoded_variable_t>(encoded_vars.get()),
-                encoded_vars_length,
-                all_dictionary_vars,
-                dictionary_var_end_offsets.get(),
-                dictionary_var_end_offsets_length
-        );
-
-        if (message.length() > cJSizeMax) {
-            JavaIOException::throw_in_java(jni_env, "message can't fit in Java byte array");
-            return nullptr;
-        }
-        auto message_bytes = jni_env->NewByteArray(static_cast<jsize>(message.length()));
-        if (nullptr == message_bytes) {
-            return nullptr;
-        }
-        jni_env->SetByteArrayRegion(message_bytes, 0, static_cast<jsize>(message.length()),
-                                    size_checked_pointer_cast<jbyte>(message.data()));
-        return message_bytes;
-    } catch (const ffi::EncodingException& e) {
-        JavaIOException::throw_in_java(jni_env, e.what());
-        return nullptr;
-    }
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
+    return decode_message_native(jni_env, Java_logtype, Java_allDictionaryVars,
+                                 Java_dictionaryVarEndOffsets, Java_encodedVars);
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(nullptr)
 }
 
 JNIEXPORT jboolean JNICALL
@@ -183,6 +134,54 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_wildcardQueryMatchesAnyInt
         jbyteArray Java_logtype,
         jlongArray Java_encoded_vars
 ) {
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     return jni_wildcard_query_matches_any_encoded_var<VariablePlaceholder::Integer>(
             jni_env, Java_wildcard_query, Java_logtype, Java_encoded_vars);
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(false)
+}
+
+static jbyteArray decode_message_native (JNIEnv* jni_env, jbyteArray Java_logtype,
+                                         jbyteArray Java_allDictionaryVars,
+                                         jintArray Java_dictionaryVarEndOffsets,
+                                         jlongArray Java_encodedVars)
+{
+    // Get logtype
+    auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(jni_env, Java_logtype,
+                                                                              JNI_ABORT);
+    auto logtype_length = jni_env->GetArrayLength(Java_logtype);
+    string_view logtype(size_checked_pointer_cast<char>(logtype_bytes.get()), logtype_length);
+
+    // Get dictionary variables
+    auto all_dictionary_vars_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
+            jni_env, Java_allDictionaryVars, JNI_ABORT);
+    auto all_dictionary_vars_length = jni_env->GetArrayLength(Java_allDictionaryVars);
+    string_view all_dictionary_vars(
+            size_checked_pointer_cast<char>(all_dictionary_vars_bytes.get()),
+            all_dictionary_vars_length);
+
+    auto dictionary_var_end_offsets = get_java_primitive_array_elements<jintArray, jint>(
+            jni_env, Java_dictionaryVarEndOffsets, JNI_ABORT);
+    auto dictionary_var_end_offsets_length = jni_env->GetArrayLength(Java_dictionaryVarEndOffsets);
+
+    // Get encoded variables
+    auto encoded_vars = get_java_primitive_array_elements<jlongArray, jlong>(
+            jni_env, Java_encodedVars, JNI_ABORT);
+    auto encoded_vars_length = jni_env->GetArrayLength(Java_encodedVars);
+
+    try {
+        auto message = decode_message(
+                logtype,
+                size_checked_pointer_cast<eight_byte_encoded_variable_t>(encoded_vars.get()),
+                encoded_vars_length,
+                all_dictionary_vars,
+                dictionary_var_end_offsets.get(),
+                dictionary_var_end_offsets_length
+        );
+
+        auto Java_message = libclp_ffi_java::new_java_primitive_array<jbyteArray, jbyte>(
+                jni_env, size_checked_pointer_cast<jbyte>(message.data()), message.length());
+        return Java_message;
+    } catch (const ffi::EncodingException& e) {
+        throw JavaIOException(__FILENAME__, __LINE__, jni_env, e.what());
+    }
 }

--- a/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
@@ -52,40 +52,6 @@ static bool jni_wildcard_query_matches_any_encoded_var (
         JNIEnv* jni_env, jbyteArray Java_wildcard_query, jbyteArray Java_logtype,
         jlongArray Java_encoded_vars);
 
-template <VariablePlaceholder var_placeholder>
-static bool jni_wildcard_query_matches_any_encoded_var (
-        JNIEnv* jni_env, jbyteArray Java_wildcard_query, jbyteArray Java_logtype,
-        jlongArray Java_encoded_vars)
-{
-    // Get logtype
-    auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
-            jni_env, Java_logtype, JNI_ABORT);
-    auto logtype_length = jni_env->GetArrayLength(Java_logtype);
-    string_view logtype(size_checked_pointer_cast<char>(logtype_bytes.get()), logtype_length);
-
-    // Get wildcard query
-    auto wildcard_query_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
-            jni_env, Java_wildcard_query, JNI_ABORT);
-    auto wildcard_query_length = jni_env->GetArrayLength(Java_wildcard_query);
-    string_view wildcard_query(size_checked_pointer_cast<char>(wildcard_query_bytes.get()),
-                               wildcard_query_length);
-
-    // Get encoded variables
-    auto encoded_vars = get_java_primitive_array_elements<jlongArray, jlong>(
-            jni_env, Java_encoded_vars, JNI_ABORT);
-    auto encoded_vars_length = jni_env->GetArrayLength(Java_encoded_vars);
-
-    try {
-        return wildcard_query_matches_any_encoded_var<var_placeholder>(
-                wildcard_query, logtype,
-                size_checked_pointer_cast<eight_byte_encoded_variable_t>(encoded_vars.get()),
-                encoded_vars_length
-        );
-    } catch (const ffi::EncodingException& e) {
-        throw JavaIOException(__FILENAME__, __LINE__, jni_env, e.what());
-    }
-}
-
 JNIEXPORT void JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_setVariableHandlingRuleVersions (
         JNIEnv* jni_env,
@@ -181,6 +147,40 @@ static jbyteArray decode_message_native (JNIEnv* jni_env, jbyteArray Java_logtyp
         auto Java_message = libclp_ffi_java::new_java_primitive_array<jbyteArray, jbyte>(
                 jni_env, size_checked_pointer_cast<jbyte>(message.data()), message.length());
         return Java_message;
+    } catch (const ffi::EncodingException& e) {
+        throw JavaIOException(__FILENAME__, __LINE__, jni_env, e.what());
+    }
+}
+
+template <VariablePlaceholder var_placeholder>
+static bool jni_wildcard_query_matches_any_encoded_var (
+        JNIEnv* jni_env, jbyteArray Java_wildcard_query, jbyteArray Java_logtype,
+        jlongArray Java_encoded_vars)
+{
+    // Get logtype
+    auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
+            jni_env, Java_logtype, JNI_ABORT);
+    auto logtype_length = jni_env->GetArrayLength(Java_logtype);
+    string_view logtype(size_checked_pointer_cast<char>(logtype_bytes.get()), logtype_length);
+
+    // Get wildcard query
+    auto wildcard_query_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
+            jni_env, Java_wildcard_query, JNI_ABORT);
+    auto wildcard_query_length = jni_env->GetArrayLength(Java_wildcard_query);
+    string_view wildcard_query(size_checked_pointer_cast<char>(wildcard_query_bytes.get()),
+                               wildcard_query_length);
+
+    // Get encoded variables
+    auto encoded_vars = get_java_primitive_array_elements<jlongArray, jlong>(
+            jni_env, Java_encoded_vars, JNI_ABORT);
+    auto encoded_vars_length = jni_env->GetArrayLength(Java_encoded_vars);
+
+    try {
+        return wildcard_query_matches_any_encoded_var<var_placeholder>(
+                wildcard_query, logtype,
+                size_checked_pointer_cast<eight_byte_encoded_variable_t>(encoded_vars.get()),
+                encoded_vars_length
+        );
     } catch (const ffi::EncodingException& e) {
         throw JavaIOException(__FILENAME__, __LINE__, jni_env, e.what());
     }

--- a/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
@@ -66,42 +66,6 @@ static jclass get_class_global_ref (JNIEnv* jni_env, const char* class_signature
 static void encode_message_native (JNIEnv* jni_env, jbyteArray Java_message,
                                    jobject Java_encodedMessage);
 
-static bool cache_java_encoded_message_field_ids (JNIEnv* jni_env) {
-    // Get Java class fields
-    // NOTE: GetFieldID already throws Java exceptions, so we don't need to
-    Java_EncodedMessage_logtype = jni_env->GetFieldID(Java_EncodedMessage, "logtype", "[B");
-    if (nullptr == Java_EncodedMessage_logtype) {
-        return false;
-    }
-    Java_EncodedMessage_encodedVars =
-            jni_env->GetFieldID(Java_EncodedMessage, "encodedVars", "[J");
-    if (nullptr == Java_EncodedMessage_encodedVars) {
-        return false;
-    }
-    Java_EncodedMessage_dictVarBounds =
-            jni_env->GetFieldID(Java_EncodedMessage, "dictionaryVarBounds", "[I");
-    if (nullptr == Java_EncodedMessage_dictVarBounds) {
-        return false;
-    }
-
-    return true;
-}
-
-static jclass get_class_global_ref (JNIEnv* jni_env, const char* class_signature) {
-    auto local_class_ref = jni_env->FindClass(class_signature);
-    if (nullptr == local_class_ref) {
-        throw JavaClassNotFoundException(__FILENAME__, __LINE__, jni_env, class_signature);
-    }
-    auto global_class_ref = reinterpret_cast<jclass>(jni_env->NewGlobalRef(local_class_ref));
-    if (nullptr == global_class_ref) {
-        jni_env->DeleteLocalRef(local_class_ref);
-        throw JavaRuntimeException(__FILENAME__, __LINE__, jni_env, "NewGlobalRef failed");
-    }
-    jni_env->DeleteLocalRef(local_class_ref);
-
-    return global_class_ref;
-}
-
 JNIEXPORT jint JNICALL JNI_OnLoad (JavaVM* vm, void*) {
     JNIEnv* jni_env;
     // Based on the JDK 11 JNI docs, JNI 1.6 should be sufficient for all
@@ -161,8 +125,44 @@ JNIEXPORT void JNICALL Java_com_yscope_clp_compressorfrontend_MessageEncoder_enc
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END()
 }
 
-void encode_message_native (JNIEnv* jni_env, jbyteArray Java_message,
-                            jobject Java_encodedMessage)
+static bool cache_java_encoded_message_field_ids (JNIEnv* jni_env) {
+    // Get Java class fields
+    // NOTE: GetFieldID already throws Java exceptions, so we don't need to
+    Java_EncodedMessage_logtype = jni_env->GetFieldID(Java_EncodedMessage, "logtype", "[B");
+    if (nullptr == Java_EncodedMessage_logtype) {
+        return false;
+    }
+    Java_EncodedMessage_encodedVars =
+            jni_env->GetFieldID(Java_EncodedMessage, "encodedVars", "[J");
+    if (nullptr == Java_EncodedMessage_encodedVars) {
+        return false;
+    }
+    Java_EncodedMessage_dictVarBounds =
+            jni_env->GetFieldID(Java_EncodedMessage, "dictionaryVarBounds", "[I");
+    if (nullptr == Java_EncodedMessage_dictVarBounds) {
+        return false;
+    }
+
+    return true;
+}
+
+static jclass get_class_global_ref (JNIEnv* jni_env, const char* class_signature) {
+    auto local_class_ref = jni_env->FindClass(class_signature);
+    if (nullptr == local_class_ref) {
+        throw JavaClassNotFoundException(__FILENAME__, __LINE__, jni_env, class_signature);
+    }
+    auto global_class_ref = reinterpret_cast<jclass>(jni_env->NewGlobalRef(local_class_ref));
+    if (nullptr == global_class_ref) {
+        jni_env->DeleteLocalRef(local_class_ref);
+        throw JavaRuntimeException(__FILENAME__, __LINE__, jni_env, "NewGlobalRef failed");
+    }
+    jni_env->DeleteLocalRef(local_class_ref);
+
+    return global_class_ref;
+}
+
+static void encode_message_native (JNIEnv* jni_env, jbyteArray Java_message,
+                                   jobject Java_encodedMessage)
 {
     // Get the message
     auto message_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(

--- a/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
@@ -22,15 +22,14 @@
 #include "JavaException.hpp"
 
 using ffi::encode_message;
-using libclp_ffi_java::cJSizeMax;
 using libclp_ffi_java::get_java_primitive_array_elements;
 using libclp_ffi_java::JavaClassNotFoundException;
 using libclp_ffi_java::JavaIOException;
 using libclp_ffi_java::JavaRuntimeException;
+using libclp_ffi_java::new_java_primitive_array;
 using libclp_ffi_java::size_checked_pointer_cast;
 using std::string_view;
 using std::string;
-using std::unique_ptr;
 using std::vector;
 
 // Constants
@@ -57,6 +56,15 @@ static bool cache_java_encoded_message_field_ids (JNIEnv* jni_env);
  * @return The reference
  */
 static jclass get_class_global_ref (JNIEnv* jni_env, const char* class_signature);
+
+/**
+ * See MessageEncoder::encodeMessageNative in Java
+ * @param jni_env
+ * @param Java_message
+ * @param Java_encodedMessage
+ */
+static void encode_message_native (JNIEnv* jni_env, jbyteArray Java_message,
+                                   jobject Java_encodedMessage);
 
 static bool cache_java_encoded_message_field_ids (JNIEnv* jni_env) {
     // Get Java class fields
@@ -136,8 +144,10 @@ Java_com_yscope_clp_compressorfrontend_MessageEncoder_setVariableHandlingRuleVer
         jbyteArray Java_variablesSchemaVersion,
         jbyteArray Java_variableEncodingMethodsVersion
 ) {
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,
                                                               Java_variableEncodingMethodsVersion);
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END()
 }
 
 JNIEXPORT void JNICALL Java_com_yscope_clp_compressorfrontend_MessageEncoder_encodeMessageNative (
@@ -146,68 +156,48 @@ JNIEXPORT void JNICALL Java_com_yscope_clp_compressorfrontend_MessageEncoder_enc
         jbyteArray Java_message,
         jobject Java_encodedMessage
 ) {
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
+    encode_message_native(jni_env, Java_message, Java_encodedMessage);
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END()
+}
+
+void encode_message_native (JNIEnv* jni_env, jbyteArray Java_message,
+                            jobject Java_encodedMessage)
+{
     // Get the message
     auto message_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
             jni_env, Java_message, JNI_ABORT);
-    if (nullptr == message_bytes) {
-        return;
-    }
     auto message_length = jni_env->GetArrayLength(Java_message);
     string_view message(size_checked_pointer_cast<char>(message_bytes.get()), message_length);
 
-    std::string logtype;
-    std::vector<encoded_variable_t> encoded_vars;
-    std::vector<int32_t> dictionary_var_bounds;
+    string logtype;
+    vector<encoded_variable_t> encoded_vars;
+    vector<int32_t> dictionary_var_bounds;
     if (false == encode_message(message, logtype, encoded_vars, dictionary_var_bounds)) {
-        JavaIOException::throw_in_java(jni_env, "message contains variable placeholders");
-        return;
+        throw JavaIOException(__FILENAME__, __LINE__, jni_env,
+                              "message contains variable placeholders");
     }
 
     // Set encodedMessage.logtype
-    if (logtype.length() > cJSizeMax) {
-        JavaIOException::throw_in_java(jni_env, "logtype too long for byte array");
-        return;
-    }
-    auto Java_logtype = jni_env->NewByteArray(static_cast<jsize>(logtype.length()));
-    if (nullptr == Java_logtype) {
-        return;
-    }
-    jni_env->SetByteArrayRegion(Java_logtype, 0, static_cast<jsize>(logtype.length()),
-                                size_checked_pointer_cast<jbyte>(logtype.data()));
-    auto exception = jni_env->ExceptionOccurred();
-    if (nullptr != exception) {
-        return;
-    }
+    auto Java_logtype = new_java_primitive_array<jbyteArray, jbyte>(
+            jni_env, size_checked_pointer_cast<jbyte>(logtype.data()), logtype.length());
     jni_env->SetObjectField(Java_encodedMessage, Java_EncodedMessage_logtype, Java_logtype);
 
     // Set encodedMessage.dictionaryVarBounds
     if (false == dictionary_var_bounds.empty()) {
-        if (dictionary_var_bounds.size() > cJSizeMax) {
-            JavaIOException::throw_in_java(jni_env, "dictionaryVarBounds can't fit in Java int "
-                                                    "array");
-            return;
-        }
-        auto java_dict_var_bounds =
-                jni_env->NewIntArray(static_cast<jsize>(dictionary_var_bounds.size()));
-        jni_env->SetIntArrayRegion(java_dict_var_bounds, 0,
-                                   static_cast<jsize>(dictionary_var_bounds.size()),
-                                   dictionary_var_bounds.data());
+        auto Java_dictVarBounds = new_java_primitive_array<jintArray, jint>(
+                jni_env, size_checked_pointer_cast<jint>(dictionary_var_bounds.data()),
+                dictionary_var_bounds.size());
         jni_env->SetObjectField(Java_encodedMessage, Java_EncodedMessage_dictVarBounds,
-                                java_dict_var_bounds);
+                                Java_dictVarBounds);
     }
 
     // Set encodedMessage.encodedVars
     if (false == encoded_vars.empty()) {
-        if (encoded_vars.size() > cJSizeMax) {
-            JavaIOException::throw_in_java(jni_env, "encodedVars can't fit in Java long array");
-            return;
-        }
-        auto java_encoded_variables =
-                jni_env->NewLongArray(static_cast<jsize>(encoded_vars.size()));
-        jni_env->SetLongArrayRegion(java_encoded_variables, 0,
-                                    static_cast<jsize>(encoded_vars.size()),
-                                    size_checked_pointer_cast<jlong>(encoded_vars.data()));
+        auto Java_encodedVars = new_java_primitive_array<jlongArray, jlong>(
+                jni_env, size_checked_pointer_cast<jlong>(encoded_vars.data()),
+                encoded_vars.size());
         jni_env->SetObjectField(Java_encodedMessage, Java_EncodedMessage_encodedVars,
-                                java_encoded_variables);
+                                Java_encodedVars);
     }
 }

--- a/src/main/cpp/libclp_ffi_java/common.cpp
+++ b/src/main/cpp/libclp_ffi_java/common.cpp
@@ -37,9 +37,9 @@ namespace libclp_ffi_java {
                 size_checked_pointer_cast<char>(encoding_methods_version_bytes.get()),
                 encoding_methods_version_length);
         if (cVariableEncodingMethodsVersion != encoding_methods_version) {
-            throw JavaUnsupportedOperationException(
-                    __FILENAME__, __LINE__, jni_env,
-                    "Unsupported version for variable encoding methods");
+            throw JavaUnsupportedOperationException(__FILENAME__, __LINE__, jni_env,
+                                                    "Unsupported version for variable encoding"
+                                                    " methods");
         }
     }
 }

--- a/src/main/cpp/libclp_ffi_java/common.cpp
+++ b/src/main/cpp/libclp_ffi_java/common.cpp
@@ -12,118 +12,6 @@ using ffi::cVariablesSchemaVersion;
 using std::string_view;
 
 namespace libclp_ffi_java {
-    template<>
-    std::unique_ptr<
-            jboolean,
-            JavaPrimitiveArrayElementsDeleter<jbooleanArray, jboolean>
-    > get_java_primitive_array_elements (JNIEnv* jni_env, jbooleanArray Java_array,
-                                         jint release_mode)
-    {
-        using DeleterType = JavaPrimitiveArrayElementsDeleter<jbooleanArray, jboolean>;
-        return std::unique_ptr<jboolean, DeleterType>{
-                jni_env->GetBooleanArrayElements(Java_array, nullptr),
-                DeleterType{jni_env, Java_array, release_mode}
-        };
-    }
-
-    template<>
-    std::unique_ptr<
-            jbyte,
-            JavaPrimitiveArrayElementsDeleter<jbyteArray, jbyte>
-    > get_java_primitive_array_elements (JNIEnv* jni_env, jbyteArray Java_array,
-                                         jint release_mode)
-    {
-        using DeleterType = JavaPrimitiveArrayElementsDeleter<jbyteArray, jbyte>;
-        return std::unique_ptr<jbyte, DeleterType>{
-                jni_env->GetByteArrayElements(Java_array, nullptr),
-                DeleterType{jni_env, Java_array, release_mode}
-        };
-    }
-
-    template<>
-    std::unique_ptr<
-            jchar,
-            JavaPrimitiveArrayElementsDeleter<jcharArray, jchar>
-    > get_java_primitive_array_elements (JNIEnv* jni_env, jcharArray Java_array,
-                                         jint release_mode)
-    {
-        using DeleterType = JavaPrimitiveArrayElementsDeleter<jcharArray, jchar>;
-        return std::unique_ptr<jchar, DeleterType>{
-                jni_env->GetCharArrayElements(Java_array, nullptr),
-                DeleterType{jni_env, Java_array, release_mode}
-        };
-    }
-
-    template<>
-    std::unique_ptr<
-            jshort,
-            JavaPrimitiveArrayElementsDeleter<jshortArray, jshort>
-    > get_java_primitive_array_elements (JNIEnv* jni_env, jshortArray Java_array,
-                                         jint release_mode)
-    {
-        using DeleterType = JavaPrimitiveArrayElementsDeleter<jshortArray, jshort>;
-        return std::unique_ptr<jshort, DeleterType>{
-                jni_env->GetShortArrayElements(Java_array, nullptr),
-                DeleterType{jni_env, Java_array, release_mode}
-        };
-    }
-
-    template<>
-    std::unique_ptr<
-            jint,
-            JavaPrimitiveArrayElementsDeleter<jintArray, jint>
-    > get_java_primitive_array_elements (JNIEnv* jni_env, jintArray Java_array,
-                                         jint release_mode)
-    {
-        using DeleterType = JavaPrimitiveArrayElementsDeleter<jintArray, jint>;
-        return std::unique_ptr<jint, DeleterType>{
-                jni_env->GetIntArrayElements(Java_array, nullptr),
-                DeleterType{jni_env, Java_array, release_mode}
-        };
-    }
-
-    template<>
-    std::unique_ptr<
-            jlong,
-            JavaPrimitiveArrayElementsDeleter<jlongArray, jlong>
-    > get_java_primitive_array_elements (JNIEnv* jni_env, jlongArray Java_array,
-                                         jint release_mode)
-    {
-        using DeleterType = JavaPrimitiveArrayElementsDeleter<jlongArray, jlong>;
-        return std::unique_ptr<jlong, DeleterType>{
-                jni_env->GetLongArrayElements(Java_array, nullptr),
-                DeleterType{jni_env, Java_array, release_mode}
-        };
-    }
-
-    template<>
-    std::unique_ptr<
-            jfloat,
-            JavaPrimitiveArrayElementsDeleter<jfloatArray, jfloat>
-    > get_java_primitive_array_elements (JNIEnv* jni_env, jfloatArray Java_array,
-                                         jint release_mode)
-    {
-        using DeleterType = JavaPrimitiveArrayElementsDeleter<jfloatArray, jfloat>;
-        return std::unique_ptr<jfloat, DeleterType>{
-                jni_env->GetFloatArrayElements(Java_array, nullptr),
-                DeleterType{jni_env, Java_array, release_mode}
-        };
-    }
-
-    template<>
-    std::unique_ptr<
-            jdouble,
-            JavaPrimitiveArrayElementsDeleter<jdoubleArray, jdouble>
-    > get_java_primitive_array_elements (JNIEnv* jni_env, jdoubleArray Java_array,
-                                         jint release_mode)
-    {
-        using DeleterType = JavaPrimitiveArrayElementsDeleter<jdoubleArray, jdouble>;
-        return std::unique_ptr<jdouble, DeleterType>{
-                jni_env->GetDoubleArrayElements(Java_array, nullptr),
-                DeleterType{jni_env, Java_array, release_mode}
-        };
-    }
-
     void validate_variable_handling_rule_versions (
             JNIEnv* jni_env,
             jbyteArray Java_variablesSchemaVersion,
@@ -132,30 +20,25 @@ namespace libclp_ffi_java {
         // Validate the schemas version
         auto schema_version_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
                 jni_env, Java_variablesSchemaVersion, JNI_ABORT);
-        if (nullptr == schema_version_bytes) {
-            return;
-        }
         auto schema_version_bytes_length = jni_env->GetArrayLength(Java_variablesSchemaVersion);
         string_view schema_version(size_checked_pointer_cast<char>(schema_version_bytes.get()),
                                    schema_version_bytes_length);
         if (cVariablesSchemaVersion != schema_version) {
-            JavaUnsupportedOperationException::throw_in_java(jni_env,
-                    "Unsupported version for variables schema");
+            throw JavaUnsupportedOperationException(__FILENAME__, __LINE__, jni_env,
+                                                    "Unsupported version for variables schema");
         }
 
         // Validate the encoding methods version
         auto encoding_methods_version_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
                 jni_env, Java_variableEncodingMethodsVersion, JNI_ABORT);
-        if (nullptr == encoding_methods_version_bytes) {
-            return;
-        }
         auto encoding_methods_version_length =
                 jni_env->GetArrayLength(Java_variableEncodingMethodsVersion);
         string_view encoding_methods_version(
                 size_checked_pointer_cast<char>(encoding_methods_version_bytes.get()),
                 encoding_methods_version_length);
         if (cVariableEncodingMethodsVersion != encoding_methods_version) {
-            JavaUnsupportedOperationException::throw_in_java(jni_env,
+            throw JavaUnsupportedOperationException(
+                    __FILENAME__, __LINE__, jni_env,
                     "Unsupported version for variable encoding methods");
         }
     }

--- a/src/main/cpp/libclp_ffi_java/common.hpp
+++ b/src/main/cpp/libclp_ffi_java/common.hpp
@@ -25,6 +25,10 @@ namespace libclp_ffi_java {
      * @param release_mode The JNI primitive array release mode (see the
      * docs for JNIEnv::Release<Primitive>ArrayElements)
      * @return A unique pointer to the native version of the array
+     * @throw libclp_ffi_java::JavaExceptionOccurred if we couldn't get the
+     * array due to a Java exception.
+     * @throw libclp_ffi_java::GeneralException if we couldn't get the array
+     * for another reason.
      */
     template <typename JavaArrayType, typename NativeArrayElementType>
     std::unique_ptr<
@@ -32,6 +36,26 @@ namespace libclp_ffi_java {
             JavaPrimitiveArrayElementsDeleter<JavaArrayType, NativeArrayElementType>
     > get_java_primitive_array_elements (JNIEnv* jni_env, JavaArrayType Java_array,
                                          jint release_mode);
+
+    /**
+     * Creates a new Java primitive array and initializes it with the contents
+     * of the given buffer.
+     * @tparam JavaArrayType The Java array's type (e.g., jbooleanArray)
+     * @tparam NativeArrayElementType The type of elements of the native array
+     * @param jni_env
+     * @param buf The elements to initialize the Java array with
+     * @param buf_len The number of elements
+     * @return The Java array
+     * @throw libclp_ffi_java::JavaUnsupportedOperationException if \p buf_len
+     * can't fit in a Java array.
+     * @throw libclp_ffi_java::JavaExceptionOccurredOperationException if the
+     * array couldn't be allocated or copied into due to a Java exception.
+     * @throw libclp_ffi_java::GeneralException if the array couldn't be
+     * allocated or copied into for another reason.
+     */
+    template <typename JavaArrayType, typename NativeArrayElementType>
+    JavaArrayType new_java_primitive_array (JNIEnv* jni_env, const NativeArrayElementType* buf,
+                                            size_t buf_len);
 
     /**
      * Cast between pointers after ensuring the source and destination types are
@@ -62,5 +86,7 @@ namespace libclp_ffi_java {
             jbyteArray Java_variableEncodingMethodsVersion
     );
 }
+
+#include "common.tpp"
 
 #endif // LIBCLP_FFI_JAVA_COMMON_HPP

--- a/src/main/cpp/libclp_ffi_java/common.tpp
+++ b/src/main/cpp/libclp_ffi_java/common.tpp
@@ -1,0 +1,151 @@
+#ifndef LIBCLP_FFI_JAVA_COMMON_TPP
+#define LIBCLP_FFI_JAVA_COMMON_TPP
+
+// C++ standard libraries
+#include <functional>
+
+// Project headers
+#include "JavaException.hpp"
+#include "GeneralException.hpp"
+
+namespace libclp_ffi_java {
+    // Local function prototypes
+    /**
+     * Copies \p buf_len elements of \p buf to the Java array \p Java_array,
+     * starting at \p begin_pos. Callers must ensure \p begin_pos and \p
+     * buf_len can fit in sizeof(jsize).
+     * @tparam JavaArrayType The Java array's type (e.g., jbooleanArray)
+     * @tparam NativeArrayElementType The type of elements of the native array
+     * @param jni_env
+     * @param Java_array The Java primitive array
+     * @param begin_pos The position in \p Java_array to start writing from
+     * @param buf The elements to copy
+     * @param buf_len The number of elements to copy
+     * @throw libclp_ffi_java::JavaExceptionOccurred if the array couldn't be
+     * copied into.
+     */
+    template <typename JavaArrayType, typename NativeArrayElementType>
+    static void copy_primitive_array_to_java_unsafe (JNIEnv* jni_env, JavaArrayType Java_array,
+                                                     size_t begin_pos,
+                                                     const NativeArrayElementType* buf,
+                                                     size_t buf_len);
+
+    template <typename JavaArrayType, typename NativeArrayElementType>
+    std::unique_ptr<
+            NativeArrayElementType,
+            JavaPrimitiveArrayElementsDeleter<JavaArrayType, NativeArrayElementType>
+    > get_java_primitive_array_elements (JNIEnv* jni_env, JavaArrayType Java_array,
+                                         jint release_mode)
+    {
+        std::function<NativeArrayElementType*(JNIEnv*, JavaArrayType, jboolean*)> get_array;
+        if constexpr (std::is_same_v<JavaArrayType, jbooleanArray>) {
+            get_array = &JNIEnv::GetBooleanArrayElements;
+        } else if constexpr (std::is_same_v<JavaArrayType, jbyteArray>) {
+            get_array = &JNIEnv::GetByteArrayElements;
+        } else if constexpr (std::is_same_v<JavaArrayType, jcharArray>) {
+            get_array = &JNIEnv::GetCharArrayElements;
+        } else if constexpr (std::is_same_v<JavaArrayType, jshortArray>) {
+            get_array = &JNIEnv::GetShortArrayElements;
+        } else if constexpr (std::is_same_v<JavaArrayType, jintArray>) {
+            get_array = &JNIEnv::GetIntArrayElements;
+        } else if constexpr (std::is_same_v<JavaArrayType, jlongArray>) {
+            get_array = &JNIEnv::GetLongArrayElements;
+        } else if constexpr (std::is_same_v<JavaArrayType, jfloatArray>) {
+            get_array = &JNIEnv::GetFloatArrayElements;
+        } else if constexpr (std::is_same_v<JavaArrayType, jdoubleArray>) {
+            get_array = &JNIEnv::GetDoubleArrayElements;
+        }
+
+        using DeleterType =
+                JavaPrimitiveArrayElementsDeleter<JavaArrayType, NativeArrayElementType>;
+        auto array = std::unique_ptr<NativeArrayElementType, DeleterType>{
+                get_array(jni_env, Java_array, nullptr),
+                DeleterType{jni_env, Java_array, release_mode}};
+        auto exception = jni_env->ExceptionOccurred();
+        if (nullptr != exception) {
+            throw JavaExceptionOccurred(ErrorCode_Failure, __FILENAME__, __LINE__,
+                                        "Get<Primitive>ArrayElements failed");
+        }
+        if (nullptr == array) {
+            throw GeneralException(ErrorCode_Failure, __FILENAME__, __LINE__,
+                                   "Get<Primitive>ArrayElements failed");
+        }
+        return array;
+    }
+
+    template <typename JavaArrayType, typename NativeArrayElementType>
+    JavaArrayType new_java_primitive_array (JNIEnv* jni_env, const NativeArrayElementType* buf,
+                                            size_t buf_len)
+    {
+        if (buf_len > cJSizeMax) {
+            throw JavaUnsupportedOperationException(__FILENAME__, __LINE__, jni_env,
+                                                    "Data can't fit in a Java array");
+        }
+        std::function<JavaArrayType(JNIEnv*, jsize)> new_array;
+        if constexpr (std::is_same_v<JavaArrayType, jbooleanArray>) {
+            new_array = &JNIEnv::NewBooleanArray;
+        } else if constexpr (std::is_same_v<JavaArrayType, jbyteArray>) {
+            new_array = &JNIEnv::NewByteArray;
+        } else if constexpr (std::is_same_v<JavaArrayType, jcharArray>) {
+            new_array = &JNIEnv::NewCharArray;
+        } else if constexpr (std::is_same_v<JavaArrayType, jshortArray>) {
+            new_array = &JNIEnv::NewShortArray;
+        } else if constexpr (std::is_same_v<JavaArrayType, jintArray>) {
+            new_array = &JNIEnv::NewIntArray;
+        } else if constexpr (std::is_same_v<JavaArrayType, jlongArray>) {
+            new_array = &JNIEnv::NewLongArray;
+        } else if constexpr (std::is_same_v<JavaArrayType, jfloatArray>) {
+            new_array = &JNIEnv::NewFloatArray;
+        } else if constexpr (std::is_same_v<JavaArrayType, jdoubleArray>) {
+            new_array = &JNIEnv::NewDoubleArray;
+        }
+        auto Java_array = new_array(jni_env, static_cast<jsize>(buf_len));
+        auto exception = jni_env->ExceptionOccurred();
+        if (nullptr != exception) {
+            throw JavaExceptionOccurred(ErrorCode_Failure, __FILENAME__, __LINE__,
+                                        "New<Primitive>Array failed");
+        }
+        if (nullptr == Java_array) {
+            throw GeneralException(ErrorCode_Failure, __FILENAME__, __LINE__,
+                                   "New<Primitive>Array failed");
+        }
+        copy_primitive_array_to_java_unsafe(jni_env, Java_array, 0, buf, buf_len);
+        return Java_array;
+    }
+
+    template <typename JavaArrayType, typename NativeArrayElementType>
+    static void copy_primitive_array_to_java_unsafe (JNIEnv* jni_env, JavaArrayType Java_array,
+                                                     size_t begin_pos,
+                                                     const NativeArrayElementType* buf,
+                                                     size_t buf_len)
+    {
+        std::function<void(JNIEnv*, JavaArrayType, jsize, jsize,
+                           const NativeArrayElementType*)> set_array_region;
+        if constexpr (std::is_same_v<JavaArrayType, jbooleanArray>) {
+            set_array_region = &JNIEnv::SetBooleanArrayRegion;
+        } else if constexpr (std::is_same_v<JavaArrayType, jbyteArray>) {
+            set_array_region = &JNIEnv::SetByteArrayRegion;
+        } else if constexpr (std::is_same_v<JavaArrayType, jcharArray>) {
+            set_array_region = &JNIEnv::SetCharArrayRegion;
+        } else if constexpr (std::is_same_v<JavaArrayType, jshortArray>) {
+            set_array_region = &JNIEnv::SetShortArrayRegion;
+        } else if constexpr (std::is_same_v<JavaArrayType, jintArray>) {
+            set_array_region = &JNIEnv::SetIntArrayRegion;
+        } else if constexpr (std::is_same_v<JavaArrayType, jlongArray>) {
+            set_array_region = &JNIEnv::SetLongArrayRegion;
+        } else if constexpr (std::is_same_v<JavaArrayType, jfloatArray>) {
+            set_array_region = &JNIEnv::SetFloatArrayRegion;
+        } else if constexpr (std::is_same_v<JavaArrayType, jdoubleArray>) {
+            set_array_region = &JNIEnv::SetDoubleArrayRegion;
+        }
+        set_array_region(jni_env, Java_array, static_cast<jsize>(begin_pos),
+                         static_cast<jsize>(buf_len), buf);
+        auto exception = jni_env->ExceptionOccurred();
+        if (nullptr != exception) {
+            throw JavaExceptionOccurred(ErrorCode_Failure, __FILENAME__, __LINE__,
+                                        "Set<Primitive>>ArrayRegion failed");
+        }
+    }
+}
+
+#endif // LIBCLP_FFI_JAVA_COMMON_TPP

--- a/src/main/cpp/libclp_ffi_java/common.tpp
+++ b/src/main/cpp/libclp_ffi_java/common.tpp
@@ -9,6 +9,13 @@
 #include "GeneralException.hpp"
 
 namespace libclp_ffi_java {
+    /**
+     * False boolean dependent on a template parameter to workaround C++'s
+     * behaviour which prevents static_assert(false);
+     */
+    template<typename>
+    inline constexpr bool dependent_false_v = false;
+
     // Local function prototypes
     /**
      * Copies \p buf_len elements of \p buf to the Java array \p Java_array,
@@ -54,6 +61,10 @@ namespace libclp_ffi_java {
             get_array = &JNIEnv::GetFloatArrayElements;
         } else if constexpr (std::is_same_v<JavaArrayType, jdoubleArray>) {
             get_array = &JNIEnv::GetDoubleArrayElements;
+        } else {
+            // NOTE: NativeArrayElementType is validated by the compiler based
+            // on JavaArrayType
+            static_assert(dependent_false_v<JavaArrayType>, "Unsupported type for JavaArrayType");
         }
 
         using DeleterType =
@@ -98,6 +109,10 @@ namespace libclp_ffi_java {
             new_array = &JNIEnv::NewFloatArray;
         } else if constexpr (std::is_same_v<JavaArrayType, jdoubleArray>) {
             new_array = &JNIEnv::NewDoubleArray;
+        } else {
+            // NOTE: NativeArrayElementType is validated by the compiler based
+            // on JavaArrayType
+            static_assert(dependent_false_v<JavaArrayType>, "Unsupported type for JavaArrayType");
         }
         auto Java_array = new_array(jni_env, static_cast<jsize>(buf_len));
         auto exception = jni_env->ExceptionOccurred();
@@ -137,6 +152,10 @@ namespace libclp_ffi_java {
             set_array_region = &JNIEnv::SetFloatArrayRegion;
         } else if constexpr (std::is_same_v<JavaArrayType, jdoubleArray>) {
             set_array_region = &JNIEnv::SetDoubleArrayRegion;
+        } else {
+            // NOTE: NativeArrayElementType is validated by the compiler based
+            // on JavaArrayType
+            static_assert(dependent_false_v<JavaArrayType>, "Unsupported type for JavaArrayType");
         }
         set_array_region(jni_env, Java_array, static_cast<jsize>(begin_pos),
                          static_cast<jsize>(buf_len), buf);

--- a/src/main/cpp/libclp_ffi_java/ir_stream/common.hpp
+++ b/src/main/cpp/libclp_ffi_java/ir_stream/common.hpp
@@ -1,10 +1,6 @@
 #ifndef LIBCLP_FFI_JAVA_IR_STREAM_COMMON_HPP
 #define LIBCLP_FFI_JAVA_IR_STREAM_COMMON_HPP
 
-// C++ standard libraries
-#include <cstdint>
-#include <vector>
-
 // JNI
 #include <jni.h>
 

--- a/src/main/cpp/libclp_ffi_java/ir_stream/common.tpp
+++ b/src/main/cpp/libclp_ffi_java/ir_stream/common.tpp
@@ -31,6 +31,13 @@ namespace libclp_ffi_java::ir_stream {
             jint time_zone_id_length,
             jlong reference_timestamp
     ) {
+        if (timestamp_pattern_length < 0 || timestamp_pattern_syntax_length < 0
+            || time_zone_id_length < 0)
+        {
+            throw JavaIllegalArgumentException(__FILENAME__, __LINE__, jni_env,
+                                               "[native] Byte array lengths cannot be negative.");
+        }
+
         // Get the timestamp pattern
         auto timestamp_pattern_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
                 jni_env, Java_timestampPattern, JNI_ABORT);

--- a/src/main/java/com/yscope/clp/compressorfrontend/MessageDecoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/MessageDecoder.java
@@ -91,7 +91,7 @@ public class MessageDecoder {
       String wildcardQuery,
       String logtype,
       long[] encodedVars
-  ) {
+  ) throws IOException {
     return wildcardQueryMatchesAnyIntVarNative(wildcardQuery.getBytes(StandardCharsets.ISO_8859_1),
         logtype.getBytes(StandardCharsets.ISO_8859_1), encodedVars);
   }
@@ -100,7 +100,7 @@ public class MessageDecoder {
       byte[] wildcardQuery,
       byte[] logtype,
       long[] encodedVars
-  );
+  ) throws IOException;
 
   /**
    * Checks whether any encoded float variable matches the given wildcard query


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The current code relies on developers to ensure that no exceptions are thrown from their code since unhandled exceptions will kill the JVM. This PR introduces macros which wrap every JNI method body to ensure most exceptions are caught and propagated to the JVM gracefully. Relying on exceptions also allows us to simplify a lot of error handling.

This PR also handles errors from JNI methods that were not handled before.

# Validation performed
<!-- What tests and validation you performed on the change -->
Validated all unit tests continue to pass.
