### PR TITLE
Handle params which could be null and shouldn't be null.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,13 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>24.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Dependencies for testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/cpp/libclp_ffi_java/Java_AbstractClpWildcardQueryEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_AbstractClpWildcardQueryEncoder.cpp
@@ -9,8 +9,10 @@ Java_com_yscope_clp_compressorfrontend_AbstractClpWildcardQueryEncoder_setVariab
 (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_variablesSchemaVersion, jint variables_schema_version_len,
-        jbyteArray Java_variableEncodingMethodsVersion, jint variable_encoding_methods_len
+        jbyteArray Java_variablesSchemaVersion,
+        jint variables_schema_version_len,
+        jbyteArray Java_variableEncodingMethodsVersion,
+        jint variable_encoding_methods_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,

--- a/src/main/cpp/libclp_ffi_java/Java_AbstractClpWildcardQueryEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_AbstractClpWildcardQueryEncoder.cpp
@@ -9,10 +9,8 @@ Java_com_yscope_clp_compressorfrontend_AbstractClpWildcardQueryEncoder_setVariab
 (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_variablesSchemaVersion,
-        jint variables_schema_version_len,
-        jbyteArray Java_variableEncodingMethodsVersion,
-        jint variable_encoding_methods_len
+        jbyteArray Java_variablesSchemaVersion, jint variables_schema_version_len,
+        jbyteArray Java_variableEncodingMethodsVersion, jint variable_encoding_methods_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,

--- a/src/main/cpp/libclp_ffi_java/Java_AbstractClpWildcardQueryEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_AbstractClpWildcardQueryEncoder.cpp
@@ -10,10 +10,14 @@ Java_com_yscope_clp_compressorfrontend_AbstractClpWildcardQueryEncoder_setVariab
         JNIEnv* jni_env,
         jobject,
         jbyteArray Java_variablesSchemaVersion,
-        jbyteArray Java_variableEncodingMethodsVersion
+        jint variables_schema_version_len,
+        jbyteArray Java_variableEncodingMethodsVersion,
+        jint variable_encoding_methods_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,
-                                                              Java_variableEncodingMethodsVersion);
+                                                              variables_schema_version_len,
+                                                              Java_variableEncodingMethodsVersion,
+                                                              variable_encoding_methods_len);
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END()
 }

--- a/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
@@ -70,10 +70,14 @@ static void batch_encoded_vars_wildcard_match_native (
  */
 static jbyteArray decode_message_native (
         JNIEnv* jni_env,
-        jbyteArray Java_logtype, jint logtype_len,
-        jbyteArray Java_allDictionaryVars, jint all_dictionary_vars_len,
-        jintArray Java_dictionaryVarEndOffsets, jint dictionary_var_end_offsets_len,
-        jlongArray Java_encodedVars, jint encoded_vars_len
+        jbyteArray Java_logtype,
+        jint logtype_len,
+        jbyteArray Java_allDictionaryVars,
+        jint all_dictionary_vars_len,
+        jintArray Java_dictionaryVarEndOffsets,
+        jint dictionary_var_end_offsets_len,
+        jlongArray Java_encodedVars,
+        jint encoded_vars_len
 );
 
 /**
@@ -91,17 +95,22 @@ static jbyteArray decode_message_native (
 template <VariablePlaceholder var_placeholder>
 static bool jni_wildcard_query_matches_any_encoded_var (
         JNIEnv* jni_env,
-        jbyteArray Java_wildcardQuery, jint wildcard_query_len,
-        jbyteArray Java_logtype, jint logtype_len,
-        jlongArray Java_encodedVars, jint encoded_vars_len
+        jbyteArray Java_wildcardQuery,
+        jint wildcard_query_len,
+        jbyteArray Java_logtype,
+        jint logtype_len,
+        jlongArray Java_encodedVars,
+        jint encoded_vars_len
 );
 
 JNIEXPORT void JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_setVariableHandlingRuleVersions (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_variablesSchemaVersion, jint variables_schema_version_len,
-        jbyteArray Java_variableEncodingMethodsVersion, jint variable_encoding_methods_len
+        jbyteArray Java_variablesSchemaVersion,
+        jint variables_schema_version_len,
+        jbyteArray Java_variableEncodingMethodsVersion,
+        jint variable_encoding_methods_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,
@@ -115,10 +124,14 @@ JNIEXPORT jbyteArray JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_logtype, jint logtype_len,
-        jbyteArray Java_allDictionaryVars, jint all_dictionary_vars_len,
-        jintArray Java_dictionaryVarEndOffsets, jint dictionary_var_end_offsets_len,
-        jlongArray Java_encodedVars, jint encoded_vars_len
+        jbyteArray Java_logtype,
+        jint logtype_len,
+        jbyteArray Java_allDictionaryVars,
+        jint all_dictionary_vars_len,
+        jintArray Java_dictionaryVarEndOffsets,
+        jint dictionary_var_end_offsets_len,
+        jlongArray Java_encodedVars,
+        jint encoded_vars_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     return decode_message_native(jni_env, Java_logtype, logtype_len, Java_allDictionaryVars,
@@ -132,9 +145,12 @@ JNIEXPORT jboolean JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_wildcardQueryMatchesAnyFloatVarNative (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_wildcardQuery, jint wildcard_query_len,
-        jbyteArray Java_logtype, jint logtype_len,
-        jlongArray Java_encodedVars, jint encoded_vars_len
+        jbyteArray Java_wildcardQuery,
+        jint wildcard_query_len,
+        jbyteArray Java_logtype,
+        jint logtype_len,
+        jlongArray Java_encodedVars,
+        jint encoded_vars_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     return jni_wildcard_query_matches_any_encoded_var<VariablePlaceholder::Float>(
@@ -147,9 +163,12 @@ JNIEXPORT jboolean JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_wildcardQueryMatchesAnyIntVarNative (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_wildcardQuery, jint wildcard_query_len,
-        jbyteArray Java_logtype, jint logtype_len,
-        jlongArray Java_encodedVars, jint encoded_vars_len
+        jbyteArray Java_wildcardQuery,
+        jint wildcard_query_len,
+        jbyteArray Java_logtype,
+        jint logtype_len,
+        jlongArray Java_encodedVars,
+        jint encoded_vars_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     return jni_wildcard_query_matches_any_encoded_var<VariablePlaceholder::Integer>(
@@ -293,10 +312,14 @@ static void batch_encoded_vars_wildcard_match_native (
 
 static jbyteArray decode_message_native (
         JNIEnv* jni_env,
-        jbyteArray Java_logtype, jint logtype_len,
-        jbyteArray Java_allDictionaryVars, jint all_dictionary_vars_len,
-        jintArray Java_dictionaryVarEndOffsets, jint dictionary_var_end_offsets_len,
-        jlongArray Java_encodedVars, jint encoded_vars_len
+        jbyteArray Java_logtype,
+        jint logtype_len,
+        jbyteArray Java_allDictionaryVars,
+        jint all_dictionary_vars_len,
+        jintArray Java_dictionaryVarEndOffsets,
+        jint dictionary_var_end_offsets_len,
+        jlongArray Java_encodedVars,
+        jint encoded_vars_len
 ) {
     // Get logtype
     auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(jni_env, Java_logtype,
@@ -339,9 +362,12 @@ static jbyteArray decode_message_native (
 template <VariablePlaceholder var_placeholder>
 static bool jni_wildcard_query_matches_any_encoded_var (
         JNIEnv* jni_env,
-        jbyteArray Java_wildcardQuery, jint wildcard_query_len,
-        jbyteArray Java_logtype, jint logtype_len,
-        jlongArray Java_encodedVars, jint encoded_vars_len
+        jbyteArray Java_wildcardQuery,
+        jint wildcard_query_len,
+        jbyteArray Java_logtype,
+        jint logtype_len,
+        jlongArray Java_encodedVars,
+        jint encoded_vars_len
 ) {
     // Get logtype
     auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(

--- a/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
@@ -59,40 +59,52 @@ static void batch_encoded_vars_wildcard_match_native (
  * See MessageDecoder::decodeMessageNative in Java
  * @param jni_env
  * @param Java_logtype
+ * @param logtype_len
  * @param Java_allDictionaryVars
+ * @param all_dictionary_vars_len
  * @param Java_dictionaryVarEndOffsets
  * @param Java_encodedVars
+ * @param encoded_vars_len
  * @return The decoded message
  */
 static jbyteArray decode_message_native (JNIEnv* jni_env, jbyteArray Java_logtype,
-                                         jbyteArray Java_allDictionaryVars,
+                                         jint logtype_len, jbyteArray Java_allDictionaryVars,
+                                         jint all_dictionary_vars_len,
                                          jintArray Java_dictionaryVarEndOffsets,
-                                         jlongArray Java_encodedVars);
+                                         jlongArray Java_encodedVars, jint encoded_vars_len);
 
 /**
  * Wrapper around wildcard_query_matches_any_encoded_var which
  * @tparam var_placeholder
  * @param jni_env
- * @param Java_wildcard_query
+ * @param Java_wildcardQuery
+ * @param wildcard_query_len
  * @param Java_logtype
- * @param Java_encoded_vars
+ * @param logtype_len
+ * @param Java_encodedVars
+ * @param encoded_vars_len
  * @return true if a match was found, false otherwise
  */
 template <VariablePlaceholder var_placeholder>
 static bool jni_wildcard_query_matches_any_encoded_var (
-        JNIEnv* jni_env, jbyteArray Java_wildcard_query, jbyteArray Java_logtype,
-        jlongArray Java_encoded_vars);
+        JNIEnv* jni_env, jbyteArray Java_wildcardQuery, jint wildcard_query_len,
+        jbyteArray Java_logtype, jint logtype_len, jlongArray Java_encodedVars,
+        jint encoded_vars_len);
 
 JNIEXPORT void JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_setVariableHandlingRuleVersions (
         JNIEnv* jni_env,
         jobject,
         jbyteArray Java_variablesSchemaVersion,
-        jbyteArray Java_variableEncodingMethodsVersion
+        jint variables_schema_version_len,
+        jbyteArray Java_variableEncodingMethodsVersion,
+        jint variable_encoding_methods_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,
-                                                              Java_variableEncodingMethodsVersion);
+                                                              variables_schema_version_len,
+                                                              Java_variableEncodingMethodsVersion,
+                                                              variable_encoding_methods_len);
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END()
 }
 
@@ -101,13 +113,17 @@ Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
         JNIEnv* jni_env,
         jobject,
         jbyteArray Java_logtype,
+        jint logtype_len,
         jbyteArray Java_allDictionaryVars,
+        jint all_dictionary_vars_len,
         jintArray Java_dictionaryVarEndOffsets,
-        jlongArray Java_encodedVars
+        jlongArray Java_encodedVars,
+        jint encoded_vars_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
-    return decode_message_native(jni_env, Java_logtype, Java_allDictionaryVars,
-                                 Java_dictionaryVarEndOffsets, Java_encodedVars);
+    return decode_message_native(jni_env, Java_logtype, logtype_len, Java_allDictionaryVars,
+                                 all_dictionary_vars_len, Java_dictionaryVarEndOffsets,
+                                 Java_encodedVars, encoded_vars_len);
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(nullptr)
 }
 
@@ -115,25 +131,35 @@ JNIEXPORT jboolean JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_wildcardQueryMatchesAnyFloatVarNative (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_wildcard_query,
+        jbyteArray Java_wildcardQuery,
+        jint wildcard_query_len,
         jbyteArray Java_logtype,
-        jlongArray Java_encoded_vars
+        jint logtype_len,
+        jlongArray Java_encodedVars,
+        jint encoded_vars_len
 ) {
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     return jni_wildcard_query_matches_any_encoded_var<VariablePlaceholder::Float>(
-            jni_env, Java_wildcard_query, Java_logtype, Java_encoded_vars);
+            jni_env, Java_wildcardQuery, wildcard_query_len, Java_logtype, logtype_len,
+            Java_encodedVars, encoded_vars_len);
+    LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(false)
 }
 
 JNIEXPORT jboolean JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_wildcardQueryMatchesAnyIntVarNative (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_wildcard_query,
+        jbyteArray Java_wildcardQuery,
+        jint wildcard_query_len,
         jbyteArray Java_logtype,
-        jlongArray Java_encoded_vars
+        jint logtype_len,
+        jlongArray Java_encodedVars,
+        jint encoded_vars_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     return jni_wildcard_query_matches_any_encoded_var<VariablePlaceholder::Integer>(
-            jni_env, Java_wildcard_query, Java_logtype, Java_encoded_vars);
+            jni_env, Java_wildcardQuery, wildcard_query_len, Java_logtype, logtype_len,
+            Java_encodedVars, encoded_vars_len);
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(false)
 }
 
@@ -245,12 +271,12 @@ static void batch_encoded_vars_wildcard_match_native (
             throw JavaExceptionOccurred(ErrorCode_Failure, __FILENAME__, __LINE__,
                                         "GetObjectArrayElement failed");
         }
-        auto logtype_len = jni_env->GetArrayLength(Java_logtype);
+        auto logtype_len = nullptr == Java_logtype ? 0 : jni_env->GetArrayLength(Java_logtype);
         auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(jni_env,
                                                                                   Java_logtype,
                                                                                   JNI_ABORT);
-        auto logtype = string_view{size_checked_pointer_cast<char>(logtype_bytes.get()),
-                                   static_cast<size_t>(logtype_len)};
+        string_view logtype{size_checked_pointer_cast<char>(logtype_bytes.get()),
+                            static_cast<size_t>(logtype_len)};
 
         try {
             match_results[i] = wildcard_match_encoded_vars(
@@ -271,41 +297,39 @@ static void batch_encoded_vars_wildcard_match_native (
 }
 
 static jbyteArray decode_message_native (JNIEnv* jni_env, jbyteArray Java_logtype,
-                                         jbyteArray Java_allDictionaryVars,
+                                         jint logtype_len, jbyteArray Java_allDictionaryVars,
+                                         jint all_dictionary_vars_len,
                                          jintArray Java_dictionaryVarEndOffsets,
-                                         jlongArray Java_encodedVars)
+                                         jlongArray Java_encodedVars, jint encoded_vars_len)
 {
     // Get logtype
     auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(jni_env, Java_logtype,
                                                                               JNI_ABORT);
-    auto logtype_length = jni_env->GetArrayLength(Java_logtype);
-    string_view logtype(size_checked_pointer_cast<char>(logtype_bytes.get()), logtype_length);
+    string_view logtype{size_checked_pointer_cast<char>(logtype_bytes.get()),
+                        static_cast<size_t>(logtype_len)};
 
     // Get dictionary variables
     auto all_dictionary_vars_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
             jni_env, Java_allDictionaryVars, JNI_ABORT);
-    auto all_dictionary_vars_length = jni_env->GetArrayLength(Java_allDictionaryVars);
-    string_view all_dictionary_vars(
+    string_view all_dictionary_vars{
             size_checked_pointer_cast<char>(all_dictionary_vars_bytes.get()),
-            all_dictionary_vars_length);
+            static_cast<size_t>(all_dictionary_vars_len)};
 
     auto dictionary_var_end_offsets = get_java_primitive_array_elements<jintArray, jint>(
             jni_env, Java_dictionaryVarEndOffsets, JNI_ABORT);
-    auto dictionary_var_end_offsets_length = jni_env->GetArrayLength(Java_dictionaryVarEndOffsets);
 
     // Get encoded variables
     auto encoded_vars = get_java_primitive_array_elements<jlongArray, jlong>(
             jni_env, Java_encodedVars, JNI_ABORT);
-    auto encoded_vars_length = jni_env->GetArrayLength(Java_encodedVars);
 
     try {
         auto message = decode_message(
                 logtype,
                 size_checked_pointer_cast<eight_byte_encoded_variable_t>(encoded_vars.get()),
-                encoded_vars_length,
+                encoded_vars_len,
                 all_dictionary_vars,
                 dictionary_var_end_offsets.get(),
-                dictionary_var_end_offsets_length
+                all_dictionary_vars_len
         );
 
         auto Java_message = libclp_ffi_java::new_java_primitive_array<jbyteArray, jbyte>(
@@ -318,32 +342,31 @@ static jbyteArray decode_message_native (JNIEnv* jni_env, jbyteArray Java_logtyp
 
 template <VariablePlaceholder var_placeholder>
 static bool jni_wildcard_query_matches_any_encoded_var (
-        JNIEnv* jni_env, jbyteArray Java_wildcard_query, jbyteArray Java_logtype,
-        jlongArray Java_encoded_vars)
+        JNIEnv* jni_env, jbyteArray Java_wildcardQuery, jint wildcard_query_len,
+        jbyteArray Java_logtype, jint logtype_len, jlongArray Java_encodedVars,
+        jint encoded_vars_len)
 {
     // Get logtype
     auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
             jni_env, Java_logtype, JNI_ABORT);
-    auto logtype_length = jni_env->GetArrayLength(Java_logtype);
-    string_view logtype(size_checked_pointer_cast<char>(logtype_bytes.get()), logtype_length);
+    string_view logtype{size_checked_pointer_cast<char>(logtype_bytes.get()),
+                        static_cast<size_t>(logtype_len)};
 
     // Get wildcard query
     auto wildcard_query_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
-            jni_env, Java_wildcard_query, JNI_ABORT);
-    auto wildcard_query_length = jni_env->GetArrayLength(Java_wildcard_query);
-    string_view wildcard_query(size_checked_pointer_cast<char>(wildcard_query_bytes.get()),
-                               wildcard_query_length);
+            jni_env, Java_wildcardQuery, JNI_ABORT);
+    string_view wildcard_query{size_checked_pointer_cast<char>(wildcard_query_bytes.get()),
+                               static_cast<size_t>(wildcard_query_len)};
 
     // Get encoded variables
     auto encoded_vars = get_java_primitive_array_elements<jlongArray, jlong>(
-            jni_env, Java_encoded_vars, JNI_ABORT);
-    auto encoded_vars_length = jni_env->GetArrayLength(Java_encoded_vars);
+            jni_env, Java_encodedVars, JNI_ABORT);
 
     try {
         return wildcard_query_matches_any_encoded_var<var_placeholder>(
                 wildcard_query, logtype,
                 size_checked_pointer_cast<eight_byte_encoded_variable_t>(encoded_vars.get()),
-                encoded_vars_length
+                encoded_vars_len
         );
     } catch (const ffi::EncodingException& e) {
         throw JavaIOException(__FILENAME__, __LINE__, jni_env, e.what());

--- a/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageDecoder.cpp
@@ -63,15 +63,18 @@ static void batch_encoded_vars_wildcard_match_native (
  * @param Java_allDictionaryVars
  * @param all_dictionary_vars_len
  * @param Java_dictionaryVarEndOffsets
+ * @param dictionary_var_end_offsets_len
  * @param Java_encodedVars
  * @param encoded_vars_len
  * @return The decoded message
  */
-static jbyteArray decode_message_native (JNIEnv* jni_env, jbyteArray Java_logtype,
-                                         jint logtype_len, jbyteArray Java_allDictionaryVars,
-                                         jint all_dictionary_vars_len,
-                                         jintArray Java_dictionaryVarEndOffsets,
-                                         jlongArray Java_encodedVars, jint encoded_vars_len);
+static jbyteArray decode_message_native (
+        JNIEnv* jni_env,
+        jbyteArray Java_logtype, jint logtype_len,
+        jbyteArray Java_allDictionaryVars, jint all_dictionary_vars_len,
+        jintArray Java_dictionaryVarEndOffsets, jint dictionary_var_end_offsets_len,
+        jlongArray Java_encodedVars, jint encoded_vars_len
+);
 
 /**
  * Wrapper around wildcard_query_matches_any_encoded_var which
@@ -87,18 +90,18 @@ static jbyteArray decode_message_native (JNIEnv* jni_env, jbyteArray Java_logtyp
  */
 template <VariablePlaceholder var_placeholder>
 static bool jni_wildcard_query_matches_any_encoded_var (
-        JNIEnv* jni_env, jbyteArray Java_wildcardQuery, jint wildcard_query_len,
-        jbyteArray Java_logtype, jint logtype_len, jlongArray Java_encodedVars,
-        jint encoded_vars_len);
+        JNIEnv* jni_env,
+        jbyteArray Java_wildcardQuery, jint wildcard_query_len,
+        jbyteArray Java_logtype, jint logtype_len,
+        jlongArray Java_encodedVars, jint encoded_vars_len
+);
 
 JNIEXPORT void JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_setVariableHandlingRuleVersions (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_variablesSchemaVersion,
-        jint variables_schema_version_len,
-        jbyteArray Java_variableEncodingMethodsVersion,
-        jint variable_encoding_methods_len
+        jbyteArray Java_variablesSchemaVersion, jint variables_schema_version_len,
+        jbyteArray Java_variableEncodingMethodsVersion, jint variable_encoding_methods_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,
@@ -112,18 +115,16 @@ JNIEXPORT jbyteArray JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_decodeMessageNative (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_logtype,
-        jint logtype_len,
-        jbyteArray Java_allDictionaryVars,
-        jint all_dictionary_vars_len,
-        jintArray Java_dictionaryVarEndOffsets,
-        jlongArray Java_encodedVars,
-        jint encoded_vars_len
+        jbyteArray Java_logtype, jint logtype_len,
+        jbyteArray Java_allDictionaryVars, jint all_dictionary_vars_len,
+        jintArray Java_dictionaryVarEndOffsets, jint dictionary_var_end_offsets_len,
+        jlongArray Java_encodedVars, jint encoded_vars_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     return decode_message_native(jni_env, Java_logtype, logtype_len, Java_allDictionaryVars,
                                  all_dictionary_vars_len, Java_dictionaryVarEndOffsets,
-                                 Java_encodedVars, encoded_vars_len);
+                                 dictionary_var_end_offsets_len, Java_encodedVars,
+                                 encoded_vars_len);
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END(nullptr)
 }
 
@@ -131,12 +132,9 @@ JNIEXPORT jboolean JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_wildcardQueryMatchesAnyFloatVarNative (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_wildcardQuery,
-        jint wildcard_query_len,
-        jbyteArray Java_logtype,
-        jint logtype_len,
-        jlongArray Java_encodedVars,
-        jint encoded_vars_len
+        jbyteArray Java_wildcardQuery, jint wildcard_query_len,
+        jbyteArray Java_logtype, jint logtype_len,
+        jlongArray Java_encodedVars, jint encoded_vars_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     return jni_wildcard_query_matches_any_encoded_var<VariablePlaceholder::Float>(
@@ -149,12 +147,9 @@ JNIEXPORT jboolean JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageDecoder_wildcardQueryMatchesAnyIntVarNative (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_wildcardQuery,
-        jint wildcard_query_len,
-        jbyteArray Java_logtype,
-        jint logtype_len,
-        jlongArray Java_encodedVars,
-        jint encoded_vars_len
+        jbyteArray Java_wildcardQuery, jint wildcard_query_len,
+        jbyteArray Java_logtype, jint logtype_len,
+        jlongArray Java_encodedVars, jint encoded_vars_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     return jni_wildcard_query_matches_any_encoded_var<VariablePlaceholder::Integer>(
@@ -296,12 +291,13 @@ static void batch_encoded_vars_wildcard_match_native (
     }
 }
 
-static jbyteArray decode_message_native (JNIEnv* jni_env, jbyteArray Java_logtype,
-                                         jint logtype_len, jbyteArray Java_allDictionaryVars,
-                                         jint all_dictionary_vars_len,
-                                         jintArray Java_dictionaryVarEndOffsets,
-                                         jlongArray Java_encodedVars, jint encoded_vars_len)
-{
+static jbyteArray decode_message_native (
+        JNIEnv* jni_env,
+        jbyteArray Java_logtype, jint logtype_len,
+        jbyteArray Java_allDictionaryVars, jint all_dictionary_vars_len,
+        jintArray Java_dictionaryVarEndOffsets, jint dictionary_var_end_offsets_len,
+        jlongArray Java_encodedVars, jint encoded_vars_len
+) {
     // Get logtype
     auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(jni_env, Java_logtype,
                                                                               JNI_ABORT);
@@ -329,7 +325,7 @@ static jbyteArray decode_message_native (JNIEnv* jni_env, jbyteArray Java_logtyp
                 encoded_vars_len,
                 all_dictionary_vars,
                 dictionary_var_end_offsets.get(),
-                all_dictionary_vars_len
+                dictionary_var_end_offsets_len
         );
 
         auto Java_message = libclp_ffi_java::new_java_primitive_array<jbyteArray, jbyte>(
@@ -342,10 +338,11 @@ static jbyteArray decode_message_native (JNIEnv* jni_env, jbyteArray Java_logtyp
 
 template <VariablePlaceholder var_placeholder>
 static bool jni_wildcard_query_matches_any_encoded_var (
-        JNIEnv* jni_env, jbyteArray Java_wildcardQuery, jint wildcard_query_len,
-        jbyteArray Java_logtype, jint logtype_len, jlongArray Java_encodedVars,
-        jint encoded_vars_len)
-{
+        JNIEnv* jni_env,
+        jbyteArray Java_wildcardQuery, jint wildcard_query_len,
+        jbyteArray Java_logtype, jint logtype_len,
+        jlongArray Java_encodedVars, jint encoded_vars_len
+) {
     // Get logtype
     auto logtype_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
             jni_env, Java_logtype, JNI_ABORT);

--- a/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
@@ -50,8 +50,10 @@ JNIEXPORT void JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageEncoder_setVariableHandlingRuleVersions (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_variablesSchemaVersion, jint variables_schema_version_len,
-        jbyteArray Java_variableEncodingMethodsVersion, jint variable_encoding_methods_len
+        jbyteArray Java_variablesSchemaVersion,
+        jint variables_schema_version_len,
+        jbyteArray Java_variableEncodingMethodsVersion,
+        jint variable_encoding_methods_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,

--- a/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
@@ -51,11 +51,15 @@ Java_com_yscope_clp_compressorfrontend_MessageEncoder_setVariableHandlingRuleVer
         JNIEnv* jni_env,
         jobject,
         jbyteArray Java_variablesSchemaVersion,
-        jbyteArray Java_variableEncodingMethodsVersion
+        jint variables_schema_version_len,
+        jbyteArray Java_variableEncodingMethodsVersion,
+        jint variable_encoding_methods_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,
-                                                              Java_variableEncodingMethodsVersion);
+                                                              variables_schema_version_len,
+                                                              Java_variableEncodingMethodsVersion,
+                                                              variable_encoding_methods_len);
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_END()
 }
 

--- a/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
+++ b/src/main/cpp/libclp_ffi_java/Java_MessageEncoder.cpp
@@ -50,10 +50,8 @@ JNIEXPORT void JNICALL
 Java_com_yscope_clp_compressorfrontend_MessageEncoder_setVariableHandlingRuleVersions (
         JNIEnv* jni_env,
         jobject,
-        jbyteArray Java_variablesSchemaVersion,
-        jint variables_schema_version_len,
-        jbyteArray Java_variableEncodingMethodsVersion,
-        jint variable_encoding_methods_len
+        jbyteArray Java_variablesSchemaVersion, jint variables_schema_version_len,
+        jbyteArray Java_variableEncodingMethodsVersion, jint variable_encoding_methods_len
 ) {
     LIBCLP_FFI_JAVA_EXCEPTION_CATCHALL_BEGIN()
     libclp_ffi_java::validate_variable_handling_rule_versions(jni_env, Java_variablesSchemaVersion,

--- a/src/main/cpp/libclp_ffi_java/common.cpp
+++ b/src/main/cpp/libclp_ffi_java/common.cpp
@@ -29,8 +29,10 @@ namespace libclp_ffi_java {
 
     void validate_variable_handling_rule_versions (
             JNIEnv* jni_env,
-            jbyteArray Java_variablesSchemaVersion, jint variables_schema_version_len,
-            jbyteArray Java_variableEncodingMethodsVersion, jint variable_encoding_methods_len
+            jbyteArray Java_variablesSchemaVersion,
+            jint variables_schema_version_len,
+            jbyteArray Java_variableEncodingMethodsVersion,
+            jint variable_encoding_methods_len
     ) {
         // Validate the schemas version
         auto schema_version_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(

--- a/src/main/cpp/libclp_ffi_java/common.cpp
+++ b/src/main/cpp/libclp_ffi_java/common.cpp
@@ -30,14 +30,15 @@ namespace libclp_ffi_java {
     void validate_variable_handling_rule_versions (
             JNIEnv* jni_env,
             jbyteArray Java_variablesSchemaVersion,
-            jbyteArray Java_variableEncodingMethodsVersion
+            jint variables_schema_version_len,
+            jbyteArray Java_variableEncodingMethodsVersion,
+            jint variable_encoding_methods_len
     ) {
         // Validate the schemas version
         auto schema_version_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
                 jni_env, Java_variablesSchemaVersion, JNI_ABORT);
-        auto schema_version_bytes_length = jni_env->GetArrayLength(Java_variablesSchemaVersion);
         string_view schema_version(size_checked_pointer_cast<char>(schema_version_bytes.get()),
-                                   schema_version_bytes_length);
+                                   variables_schema_version_len);
         if (cVariablesSchemaVersion != schema_version) {
             throw JavaUnsupportedOperationException(__FILENAME__, __LINE__, jni_env,
                                                     "Unsupported version for variables schema");
@@ -46,11 +47,9 @@ namespace libclp_ffi_java {
         // Validate the encoding methods version
         auto encoding_methods_version_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(
                 jni_env, Java_variableEncodingMethodsVersion, JNI_ABORT);
-        auto encoding_methods_version_length =
-                jni_env->GetArrayLength(Java_variableEncodingMethodsVersion);
         string_view encoding_methods_version(
                 size_checked_pointer_cast<char>(encoding_methods_version_bytes.get()),
-                encoding_methods_version_length);
+                variable_encoding_methods_len);
         if (cVariableEncodingMethodsVersion != encoding_methods_version) {
             throw JavaUnsupportedOperationException(__FILENAME__, __LINE__, jni_env,
                                                     "Unsupported version for variable encoding"

--- a/src/main/cpp/libclp_ffi_java/common.cpp
+++ b/src/main/cpp/libclp_ffi_java/common.cpp
@@ -29,10 +29,8 @@ namespace libclp_ffi_java {
 
     void validate_variable_handling_rule_versions (
             JNIEnv* jni_env,
-            jbyteArray Java_variablesSchemaVersion,
-            jint variables_schema_version_len,
-            jbyteArray Java_variableEncodingMethodsVersion,
-            jint variable_encoding_methods_len
+            jbyteArray Java_variablesSchemaVersion, jint variables_schema_version_len,
+            jbyteArray Java_variableEncodingMethodsVersion, jint variable_encoding_methods_len
     ) {
         // Validate the schemas version
         auto schema_version_bytes = get_java_primitive_array_elements<jbyteArray, jbyte>(

--- a/src/main/cpp/libclp_ffi_java/common.hpp
+++ b/src/main/cpp/libclp_ffi_java/common.hpp
@@ -94,8 +94,10 @@ namespace libclp_ffi_java {
      */
     void validate_variable_handling_rule_versions (
             JNIEnv* jni_env,
-            jbyteArray Java_variablesSchemaVersion, jint variables_schema_version_len,
-            jbyteArray Java_variableEncodingMethodsVersion, jint variable_encoding_methods_len
+            jbyteArray Java_variablesSchemaVersion,
+            jint variables_schema_version_len,
+            jbyteArray Java_variableEncodingMethodsVersion,
+            jint variable_encoding_methods_len
     );
 }
 

--- a/src/main/cpp/libclp_ffi_java/common.hpp
+++ b/src/main/cpp/libclp_ffi_java/common.hpp
@@ -24,7 +24,7 @@ namespace libclp_ffi_java {
      * @param Java_array The Java primitive array
      * @param release_mode The JNI primitive array release mode (see the
      * docs for JNIEnv::Release<Primitive>ArrayElements)
-     * @return A unique pointer to the native version of the array, or nullptr
+     * @return A unique pointer to the native version of the array, or a nullptr
      * if the Java array pointer is null
      * @throw libclp_ffi_java::JavaExceptionOccurred if we couldn't get the
      * array due to a Java exception.
@@ -94,10 +94,8 @@ namespace libclp_ffi_java {
      */
     void validate_variable_handling_rule_versions (
             JNIEnv* jni_env,
-            jbyteArray Java_variablesSchemaVersion,
-            jint variables_schema_version_len,
-            jbyteArray Java_variableEncodingMethodsVersion,
-            jint variable_encoding_methods_len
+            jbyteArray Java_variablesSchemaVersion, jint variables_schema_version_len,
+            jbyteArray Java_variableEncodingMethodsVersion, jint variable_encoding_methods_len
     );
 }
 

--- a/src/main/cpp/libclp_ffi_java/common.hpp
+++ b/src/main/cpp/libclp_ffi_java/common.hpp
@@ -24,7 +24,8 @@ namespace libclp_ffi_java {
      * @param Java_array The Java primitive array
      * @param release_mode The JNI primitive array release mode (see the
      * docs for JNIEnv::Release<Primitive>ArrayElements)
-     * @return A unique pointer to the native version of the array
+     * @return A unique pointer to the native version of the array, or nullptr
+     * if the Java array pointer is null
      * @throw libclp_ffi_java::JavaExceptionOccurred if we couldn't get the
      * array due to a Java exception.
      * @throw libclp_ffi_java::GeneralException if we couldn't get the array
@@ -87,12 +88,16 @@ namespace libclp_ffi_java {
      * library.
      * @param jni_env
      * @param Java_variablesSchemaVersion
+     * @param variables_schema_version_len
      * @param Java_variableEncodingMethodsVersion
+     * @param variable_encoding_methods_len
      */
     void validate_variable_handling_rule_versions (
             JNIEnv* jni_env,
             jbyteArray Java_variablesSchemaVersion,
-            jbyteArray Java_variableEncodingMethodsVersion
+            jint variables_schema_version_len,
+            jbyteArray Java_variableEncodingMethodsVersion,
+            jint variable_encoding_methods_len
     );
 }
 

--- a/src/main/cpp/libclp_ffi_java/common.tpp
+++ b/src/main/cpp/libclp_ffi_java/common.tpp
@@ -70,8 +70,11 @@ namespace libclp_ffi_java {
         using DeleterType =
                 JavaPrimitiveArrayElementsDeleter<JavaArrayType, NativeArrayElementType>;
         auto array = std::unique_ptr<NativeArrayElementType, DeleterType>{
-                get_array(jni_env, Java_array, nullptr),
+                nullptr == Java_array ? nullptr : get_array(jni_env, Java_array, nullptr),
                 DeleterType{jni_env, Java_array, release_mode}};
+        if (nullptr == Java_array) {
+            return array;
+        }
         auto exception = jni_env->ExceptionOccurred();
         if (nullptr != exception) {
             throw JavaExceptionOccurred(ErrorCode_Failure, __FILENAME__, __LINE__,

--- a/src/main/java/com/yscope/clp/compressorfrontend/AbstractClpWildcardQueryEncoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/AbstractClpWildcardQueryEncoder.java
@@ -37,7 +37,9 @@ public abstract class AbstractClpWildcardQueryEncoder {
   }
 
   private native void setVariableHandlingRuleVersions (
-      byte[] variablesSchemaVersion, int variablesSchemaVersionLen,
-      byte[] variableEncodingMethodsVersion, int variableEncodingMethodsVersionLen
+      byte[] variablesSchemaVersion,
+      int variablesSchemaVersionLen,
+      byte[] variableEncodingMethodsVersion,
+      int variableEncodingMethodsVersionLen
   ) throws UnsupportedOperationException;
 }

--- a/src/main/java/com/yscope/clp/compressorfrontend/AbstractClpWildcardQueryEncoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/AbstractClpWildcardQueryEncoder.java
@@ -37,9 +37,7 @@ public abstract class AbstractClpWildcardQueryEncoder {
   }
 
   private native void setVariableHandlingRuleVersions (
-      byte[] variablesSchemaVersion,
-      int variablesSchemaVersionLen,
-      byte[] variableEncodingMethodsVersion,
-      int variableEncodingMethodsVersionLen
+      byte[] variablesSchemaVersion, int variablesSchemaVersionLen,
+      byte[] variableEncodingMethodsVersion, int variableEncodingMethodsVersionLen
   ) throws UnsupportedOperationException;
 }

--- a/src/main/java/com/yscope/clp/compressorfrontend/AbstractClpWildcardQueryEncoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/AbstractClpWildcardQueryEncoder.java
@@ -1,6 +1,9 @@
 package com.yscope.clp.compressorfrontend;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Class to encode wildcard queries so that they can be used to search
@@ -20,15 +23,23 @@ public abstract class AbstractClpWildcardQueryEncoder {
    * unsupported.
    */
   public AbstractClpWildcardQueryEncoder (
-      String variablesSchemaVersion,
-      String variableEncodingMethodsVersion
+      @NotNull String variablesSchemaVersion,
+      @NotNull String variableEncodingMethodsVersion
   ) throws UnsupportedOperationException {
-    setVariableHandlingRuleVersions(variablesSchemaVersion.getBytes(StandardCharsets.ISO_8859_1),
-        variableEncodingMethodsVersion.getBytes(StandardCharsets.ISO_8859_1));
+    Objects.requireNonNull(variablesSchemaVersion);
+    Objects.requireNonNull(variableEncodingMethodsVersion);
+    byte[] schemaVersionBytes = variablesSchemaVersion.getBytes(StandardCharsets.ISO_8859_1);
+    byte[] encodingMethodsVersionBytes =
+        variableEncodingMethodsVersion.getBytes(StandardCharsets.ISO_8859_1);
+    setVariableHandlingRuleVersions(schemaVersionBytes, schemaVersionBytes.length,
+                                    encodingMethodsVersionBytes,
+                                    encodingMethodsVersionBytes.length);
   }
 
   private native void setVariableHandlingRuleVersions (
       byte[] variablesSchemaVersion,
-      byte[] variableEncodingMethodsVersion
+      int variablesSchemaVersionLen,
+      byte[] variableEncodingMethodsVersion,
+      int variableEncodingMethodsVersionLen
   ) throws UnsupportedOperationException;
 }

--- a/src/main/java/com/yscope/clp/compressorfrontend/EightByteClpWildcardQueryEncoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/EightByteClpWildcardQueryEncoder.java
@@ -1,6 +1,9 @@
 package com.yscope.clp.compressorfrontend;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Derived version of {@link AbstractClpWildcardQueryEncoder} specifically using
@@ -11,8 +14,8 @@ public class EightByteClpWildcardQueryEncoder extends AbstractClpWildcardQueryEn
    * @see AbstractClpWildcardQueryEncoder#AbstractClpWildcardQueryEncoder
    */
   public EightByteClpWildcardQueryEncoder (
-      String variablesSchemaVersion,
-      String variableEncodingMethodsVersion
+      @NotNull String variablesSchemaVersion,
+      @NotNull String variableEncodingMethodsVersion
   ) throws UnsupportedOperationException {
     super(variablesSchemaVersion, variableEncodingMethodsVersion);
   }
@@ -29,8 +32,9 @@ public class EightByteClpWildcardQueryEncoder extends AbstractClpWildcardQueryEn
    * @return The subqueries
    */
   public EightByteClpEncodedSubquery[] encode (
-      String wildcardQuery
+      @NotNull String wildcardQuery
   ) throws IllegalArgumentException {
+    Objects.requireNonNull(wildcardQuery);
     byte[] wildcardQueryBytes = wildcardQuery.getBytes(StandardCharsets.ISO_8859_1);
     return encodeNative(wildcardQueryBytes, wildcardQueryBytes.length);
   }

--- a/src/main/java/com/yscope/clp/compressorfrontend/MessageDecoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/MessageDecoder.java
@@ -40,10 +40,8 @@ public class MessageDecoder {
   }
 
   private native void setVariableHandlingRuleVersions (
-      byte[] variablesSchemaVersion,
-      int variablesSchemaVersionLen,
-      byte[] variableEncodingMethodsVersion,
-      int variableEncodingMethodsVersionLen
+      byte[] variablesSchemaVersion, int variablesSchemaVersionLen,
+      byte[] variableEncodingMethodsVersion, int variableEncodingMethodsVersionLen
   ) throws UnsupportedOperationException;
 
   /**
@@ -80,8 +78,11 @@ public class MessageDecoder {
     byte[] logtypeBytes = logtype.getBytes(StandardCharsets.ISO_8859_1);
     byte[] messageBytes = decodeMessageNative(
         logtypeBytes, logtypeBytes.length, allDictionaryVars,
-        null == allDictionaryVars ? 0 : allDictionaryVars.length, dictionaryVarEndOffsets,
-        encodedVars, null == encodedVars ? 0 : encodedVars.length);
+        null == allDictionaryVars ? 0 : allDictionaryVars.length,
+        dictionaryVarEndOffsets,
+        null == dictionaryVarEndOffsets ? 0 : dictionaryVarEndOffsets.length,
+        encodedVars,
+        null == encodedVars ? 0 : encodedVars.length);
     return new String(messageBytes, StandardCharsets.UTF_8);
   }
 
@@ -94,15 +95,19 @@ public class MessageDecoder {
    * @param allDictionaryVarsLen
    * @param dictionaryVarEndOffsets The end-offset of each dictionary variable
    *                                in {@code allDictionaryVars}
+   * @param dictionaryVarEndOffsetsLen
    * @param encodedVars The message's encoded variables
    * @param encodedVarsLen
    * @return The decoded message
    * @throws IOException if the delimiters in the logtype don't match the number
    * of variables.
    */
-  private native byte[] decodeMessageNative(byte[] logtype, int logtypeLen,
-      byte[] allDictionaryVars, int allDictionaryVarsLen, int[] dictionaryVarEndOffsets,
-      long[] encodedVars, int encodedVarsLen) throws IOException;
+  private native byte[] decodeMessageNative(
+      byte[] logtype, int logtypeLen,
+      byte[] allDictionaryVars, int allDictionaryVarsLen,
+      int[] dictionaryVarEndOffsets, int dictionaryVarEndOffsetsLen,
+      long[] encodedVars, int encodedVarsLen
+  ) throws IOException;
 
   /**
    * Checks whether any encoded integer variable matches the given wildcard
@@ -127,12 +132,9 @@ public class MessageDecoder {
   }
 
   private native boolean wildcardQueryMatchesAnyIntVarNative(
-      byte[] wildcardQuery,
-      int wildcardQueryLen,
-      byte[] logtype,
-      int logtypeLen,
-      long[] encodedVars,
-      int encodedVarsLen
+      byte[] wildcardQuery, int wildcardQueryLen,
+      byte[] logtype, int logtypeLen,
+      long[] encodedVars, int encodedVarsLen
   ) throws IOException;
 
   /**
@@ -153,16 +155,14 @@ public class MessageDecoder {
     byte[] logtypeBytes = logtype.getBytes(StandardCharsets.ISO_8859_1);
     return wildcardQueryMatchesAnyFloatVarNative(
         wildcardQueryBytes, wildcardQueryBytes.length, logtypeBytes, logtypeBytes.length,
-        encodedVars, null == encodedVars ? 0 : encodedVars.length);
+        encodedVars,
+        null == encodedVars ? 0 : encodedVars.length);
   }
 
   private native boolean wildcardQueryMatchesAnyFloatVarNative(
-      byte[] wildcardQuery,
-      int wildcardQueryLen,
-      byte[] logtype,
-      int logtypeLen,
-      long[] encodedVars,
-      int encodedVarsLen
+      byte[] wildcardQuery, int wildcardQueryLen,
+      byte[] logtype, int logtypeLen,
+      long[] encodedVars, int encodedVarsLen
   ) throws IOException;
 
   /**

--- a/src/main/java/com/yscope/clp/compressorfrontend/MessageDecoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/MessageDecoder.java
@@ -40,8 +40,10 @@ public class MessageDecoder {
   }
 
   private native void setVariableHandlingRuleVersions (
-      byte[] variablesSchemaVersion, int variablesSchemaVersionLen,
-      byte[] variableEncodingMethodsVersion, int variableEncodingMethodsVersionLen
+      byte[] variablesSchemaVersion,
+      int variablesSchemaVersionLen,
+      byte[] variableEncodingMethodsVersion,
+      int variableEncodingMethodsVersionLen
   ) throws UnsupportedOperationException;
 
   /**
@@ -103,10 +105,14 @@ public class MessageDecoder {
    * of variables.
    */
   private native byte[] decodeMessageNative(
-      byte[] logtype, int logtypeLen,
-      byte[] allDictionaryVars, int allDictionaryVarsLen,
-      int[] dictionaryVarEndOffsets, int dictionaryVarEndOffsetsLen,
-      long[] encodedVars, int encodedVarsLen
+      byte[] logtype,
+      int logtypeLen,
+      byte[] allDictionaryVars,
+      int allDictionaryVarsLen,
+      int[] dictionaryVarEndOffsets,
+      int dictionaryVarEndOffsetsLen,
+      long[] encodedVars,
+      int encodedVarsLen
   ) throws IOException;
 
   /**
@@ -132,9 +138,12 @@ public class MessageDecoder {
   }
 
   private native boolean wildcardQueryMatchesAnyIntVarNative(
-      byte[] wildcardQuery, int wildcardQueryLen,
-      byte[] logtype, int logtypeLen,
-      long[] encodedVars, int encodedVarsLen
+      byte[] wildcardQuery,
+      int wildcardQueryLen,
+      byte[] logtype,
+      int logtypeLen,
+      long[] encodedVars,
+      int encodedVarsLen
   ) throws IOException;
 
   /**
@@ -160,9 +169,12 @@ public class MessageDecoder {
   }
 
   private native boolean wildcardQueryMatchesAnyFloatVarNative(
-      byte[] wildcardQuery, int wildcardQueryLen,
-      byte[] logtype, int logtypeLen,
-      long[] encodedVars, int encodedVarsLen
+      byte[] wildcardQuery,
+      int wildcardQueryLen,
+      byte[] logtype,
+      int logtypeLen,
+      long[] encodedVars,
+      int encodedVarsLen
   ) throws IOException;
 
   /**

--- a/src/main/java/com/yscope/clp/compressorfrontend/MessageEncoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/MessageEncoder.java
@@ -39,8 +39,10 @@ public class MessageEncoder {
   }
 
   private native void setVariableHandlingRuleVersions (
-      byte[] variablesSchemaVersion, int variablesSchemaVersionLen,
-      byte[] variableEncodingMethodsVersion, int variableEncodingMethodsVersionLen
+      byte[] variablesSchemaVersion,
+      int variablesSchemaVersionLen,
+      byte[] variableEncodingMethodsVersion,
+      int variableEncodingMethodsVersionLen
   ) throws UnsupportedOperationException;
 
   /**

--- a/src/main/java/com/yscope/clp/compressorfrontend/MessageEncoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/MessageEncoder.java
@@ -39,10 +39,8 @@ public class MessageEncoder {
   }
 
   private native void setVariableHandlingRuleVersions (
-      byte[] variablesSchemaVersion,
-      int variablesSchemaVersionLen,
-      byte[] variableEncodingMethodsVersion,
-      int variableEncodingMethodsVersionLen
+      byte[] variablesSchemaVersion, int variablesSchemaVersionLen,
+      byte[] variableEncodingMethodsVersion, int variableEncodingMethodsVersionLen
   ) throws UnsupportedOperationException;
 
   /**

--- a/src/main/java/com/yscope/clp/compressorfrontend/MessageEncoder.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/MessageEncoder.java
@@ -2,6 +2,9 @@ package com.yscope.clp.compressorfrontend;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Class to encode log messages
@@ -22,16 +25,24 @@ public class MessageEncoder {
    * unsupported.
    */
   public MessageEncoder(
-      String variablesSchemaVersion,
-      String variableEncodingMethodsVersion
+      @NotNull String variablesSchemaVersion,
+      @NotNull String variableEncodingMethodsVersion
   ) throws UnsupportedOperationException {
-    setVariableHandlingRuleVersions(variablesSchemaVersion.getBytes(StandardCharsets.ISO_8859_1),
-        variableEncodingMethodsVersion.getBytes(StandardCharsets.ISO_8859_1));
+    Objects.requireNonNull(variablesSchemaVersion);
+    Objects.requireNonNull(variableEncodingMethodsVersion);
+    byte[] schemaVersionBytes = variablesSchemaVersion.getBytes(StandardCharsets.ISO_8859_1);
+    byte[] encodingMethodsVersionBytes =
+        variableEncodingMethodsVersion.getBytes(StandardCharsets.ISO_8859_1);
+    setVariableHandlingRuleVersions(schemaVersionBytes, schemaVersionBytes.length,
+                                    encodingMethodsVersionBytes,
+                                    encodingMethodsVersionBytes.length);
   }
 
   private native void setVariableHandlingRuleVersions (
       byte[] variablesSchemaVersion,
-      byte[] variableEncodingMethodsVersion
+      int variablesSchemaVersionLen,
+      byte[] variableEncodingMethodsVersion,
+      int variableEncodingMethodsVersionLen
   ) throws UnsupportedOperationException;
 
   /**


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

Various null inputs were not handled correctly leading to the possibility of segfaults since these nulls would be passed to the native code. This PR targets those specific nulls either by handling them correctly if they are valid inputs or disallowing them if they are invalid inputs.

In addition, for various native methods, this PR passes the length of arrays as an argument to avoid calling into the JVM to get the lengths (this should improve performance slightly).

# Validation performed
<!-- What tests and validation you performed on the change -->
Added new unit tests and validated all tests pass.
