### PR TITLE
Use correct Maven snapshot repo ID.

### DIFF
--- a/.github/workflows/build-and-release-package.yml
+++ b/.github/workflows/build-and-release-package.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-          server-id: 'maven'
+          server-id: 'ossrh'
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>maven</serverId>
+                            <serverId>ossrh</serverId>
                             <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

Releases to Maven are failing, possibly because the server ID configured for the nexus-staging-maven-plugin was set to a different value than the ID of the distributionManagement plugin.

This fixes that.

# Validation performed
<!-- What tests and validation you performed on the change -->

None. Will validate by attempting to release again.