### PR TITLE
gh-actions: Switch from AdoptOpenJDK to Temurin.

### DIFF
--- a/.github/workflows/build-and-release-package.yml
+++ b/.github/workflows/build-and-release-package.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           server-id: 'ossrh'
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           server-id: 'github'
 
       - name: Install requirements


### PR DESCRIPTION
# Description

AdoptOpenJDK is obsolete.  Use Temurin JDK instead.

Details here:

https://github.com/actions/setup-java/blob/main/README.md


# Validation performed
<!-- What tests and validation you performed on the change -->


