### PR TITLE
gh-actions: Update to latest versions of all actions; Reduce artifact retention period.

### DIFF
--- a/.github/workflows/build-and-release-package.yml
+++ b/.github/workflows/build-and-release-package.yml
@@ -9,7 +9,7 @@ jobs:
   build-lib-for-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -20,11 +20,12 @@ jobs:
         id: build
         uses: ./.github/actions/native-lib-build
 
-      - uses: actions/upload-artifact@main
+      - uses: actions/upload-artifact@v4
         with:
           name: libclp-ffi-java-macos
           path: ${{github.workspace}}/clp-ffi-*-native-lib/
           if-no-files-found: error
+          retention-days: 1
 
   build-package:
     needs: build-lib-for-macos
@@ -33,11 +34,11 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -56,7 +57,7 @@ jobs:
         id: build
         uses: ./.github/actions/native-lib-build
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: libclp-ffi-java-macos
           path: ./target/.

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -31,7 +31,7 @@ jobs:
   build-lib-for-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -42,11 +42,12 @@ jobs:
         id: build
         uses: ./.github/actions/native-lib-build
 
-      - uses: actions/upload-artifact@main
+      - uses: actions/upload-artifact@v4
         with:
           name: libclp-ffi-java-macos
           path: ${{github.workspace}}/clp-ffi-*-native-lib/
           if-no-files-found: error
+          retention-days: 1
 
   build-package:
     needs: build-lib-for-macos
@@ -55,11 +56,11 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -74,7 +75,7 @@ jobs:
         id: build
         uses: ./.github/actions/native-lib-build
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: libclp-ffi-java-macos
           path: ./target/.


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

The version of the `upload-artifact` action that we're using in this repo's workflows is incompatible with the version of the `download-artifact` action we're using, meaning that the package build is failing since it can't download the macOS library. In addition, several actions are configured to use deprecated versions.

This PR:

* updates all actions to use the latest versions;
* makes upload-artifact and download-artifact use compatible versions;
* reduces the retention time for uploaded artifacts from 90 days to 1 (the uploaded artifact is primarily used when releasing a new version).

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated workflows passed without deprecation warnings.