### PR TITLE
Add Taskfile tasks for build and test commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-clp-ffi-java is a library to encode log messages with 
+clp-ffi-java is a library to encode log messages with
 [CLP](https://github.com/y-scope/clp), and work with the encoded messages using
 a foreign function interface (FFI).
 
@@ -6,6 +6,7 @@ a foreign function interface (FFI).
 
 * A C++ compiler that supports C++-17
 * CMake 3.5.1 or higher
+* [Task]
 
 # Setup
 
@@ -17,32 +18,37 @@ a foreign function interface (FFI).
 
 # Common build commands
 
-* Build and test
-  ```shell
-  mvn package
-  ```
-* Build without any extras
-  ```shell
-  mvn package -DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip
-  ```
-* Generate the JNI headers
-  ```shell
-  mvn generate-sources
-  ```
-* Build the native library
-  ```shell
-  mvn generate-resources
-  ```
-* Build and package the native library
-  ```shell
-  mvn generate-resources validate assembly:single@assemble-lib-dir
-  ```
-  * The validate phase is necessary to remove spaces from the OS name
+Build and test:
+```shell
+task
+# or task package-and-test
+```
+
+Build without testing:
+```shell
+task package
+```
+
+Build without any extras:
+```shell
+task package-basic
+```
+
+Generate the JNI headers:
+```shell
+task jni-headers
+```
+
+Build and package the native library:
+```shell
+task native-lib
+```
 
 # Testing
 
+Run tests:
 ```shell
-mvn test
+task test
 ```
 
 # Linting
@@ -61,7 +67,6 @@ To run the linting tools, besides commonly installed tools like `tar`, you'll ne
 * `md5sum`
 * Python 3.8 or newer
 * python3-venv
-* [Task]
 
 ## Running the linters
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,23 @@ vars:
   G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
 
 tasks:
+  default:
+    deps: ["package-and-test"]
+
+  package-and-test: "mvn package"
+
+  package: "mvn package -DskipTests"
+
+  package-basic: "mvn package -DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip"
+
+  jni-headers: "mvn generate-sources"
+
+  native-lib:
+    # NOTE: `validate` is necessary to remove spaces from the OS name
+    cmd: "mvn generate-resources validate assembly:single@assemble-lib-dir"
+
+  test: "mvn test"
+
   lint:
     deps: ["lint-venv"]
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,7 +37,7 @@ tasks:
           Taskfile.yml
 
   clean:
-    cmds: ["rm -rf '{{.G_BUILD_DIR}}'"]
+    cmds: ["rm -rf '{{.G_BUILD_DIR}}' '{{.G_LINT_VENV_DIR}}'"]
 
   lint-venv:
     internal: true


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

This PR adds tasks to replace the building and testing commands in the README.

Note that the command to *just* build the native library without packaging it was removed since packaging doesn't add too much overhead.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated all tasks work.