### PR TITLE
Add support for getting `EncodedMessage`'s dictionary vars as byte arrays.

### DIFF
--- a/src/main/java/com/yscope/clp/compressorfrontend/EmptyArrayUtils.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/EmptyArrayUtils.java
@@ -8,6 +8,7 @@ public class EmptyArrayUtils {
   public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
   public static final int[] EMPTY_INT_ARRAY = new int[0];
   public static final long[] EMPTY_LONG_ARRAY = new long[0];
+  public static final byte[][] EMPTY_BYTE_ARRAY_ARRAY = new byte[0][];
   public static final FlattenedByteArray EMPTY_FLATTENED_BYTE_ARRAY =
       new FlattenedByteArray(EMPTY_BYTE_ARRAY, EMPTY_INT_ARRAY);
 
@@ -21,6 +22,10 @@ public class EmptyArrayUtils {
 
   public static long[] getNonNullLongArray(long[] longArray) {
     return (null == longArray) ? EMPTY_LONG_ARRAY : longArray;
+  }
+
+  public static byte[][] getEmptyByteArrayArray(byte[][] byteArrayArray) {
+    return (null == byteArrayArray) ? EMPTY_BYTE_ARRAY_ARRAY : byteArrayArray;
   }
 
   public static FlattenedByteArray getNonNullFlattenedByteArray(

--- a/src/main/java/com/yscope/clp/compressorfrontend/EncodedMessage.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/EncodedMessage.java
@@ -1,6 +1,7 @@
 package com.yscope.clp.compressorfrontend;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.LongStream;
 
@@ -63,6 +64,24 @@ public class EncodedMessage {
       int endOffset = dictionaryVarBounds[j++];
       dictVars[i] = new String(message, beginOffset,
           endOffset - beginOffset, StandardCharsets.ISO_8859_1);
+    }
+    return dictVars;
+  }
+
+  /**
+   * @return The dictionary variables instantiated as {@code byte[]}s.
+   */
+  public byte[][] getDictionaryVarsAsBytes() {
+    if (null == dictionaryVarBounds) {
+      return null;
+    }
+
+    int numVars = dictionaryVarBounds.length / 2;
+    byte[][] dictVars = new byte[numVars][];
+    for (int i = 0, j = 0; i < dictVars.length; ++i) {
+      int beginOffset = dictionaryVarBounds[j++];
+      int endOffset = dictionaryVarBounds[j++];
+      dictVars[i] = Arrays.copyOfRange(message, beginOffset, endOffset);
     }
     return dictVars;
   }

--- a/src/main/java/com/yscope/clp/compressorfrontend/EncodedMessage.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/EncodedMessage.java
@@ -71,7 +71,7 @@ public class EncodedMessage {
   /**
    * @return The dictionary variables instantiated as {@code byte[]}s.
    */
-  public byte[][] getDictionaryVarsAsBytes() {
+  public byte[][] getDictionaryVarsAsByteArrays() {
     if (null == dictionaryVarBounds) {
       return null;
     }

--- a/src/main/java/com/yscope/clp/compressorfrontend/FlattenedByteArrayFactory.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/FlattenedByteArrayFactory.java
@@ -7,6 +7,35 @@ public class FlattenedByteArrayFactory {
     private static ThreadLocal<ByteArrayOutputStream> reusableByteArrayOutputStream;
 
     /**
+     * Constructs a FlattenedByteArray by concatenating the given byte arrays together.
+     * @param byteArrays
+     * @return The flattened array.
+     */
+    public static FlattenedByteArray fromByteArrays(byte[][] byteArrays) {
+        if (null == byteArrays || 0 == byteArrays.length) {
+            return EmptyArrayUtils.EMPTY_FLATTENED_BYTE_ARRAY;
+        }
+
+        // Compute flattenedElemsEndOffsets
+        int flattenedElemsLength = 0;
+        int[] flattenedElemsEndOffsets = new int[byteArrays.length];
+        for (int i = 0; i < byteArrays.length; i++) {
+            flattenedElemsLength += byteArrays[i].length;
+            flattenedElemsEndOffsets[i] = flattenedElemsLength;
+        }
+
+        // Compute flattenedElems
+        byte[] flattenedElems = new byte[flattenedElemsLength];
+        for (int i = 0, flattenedElemsOffset = 0; i < byteArrays.length; i++) {
+            byte[] byteArray = byteArrays[i];
+            System.arraycopy(byteArray, 0, flattenedElems, flattenedElemsOffset, byteArray.length);
+            flattenedElemsOffset += byteArray.length;
+        }
+
+        return new FlattenedByteArray(flattenedElems, flattenedElemsEndOffsets);
+    }
+
+    /**
      * Constructs a FlattenedByteArray by converting the given strings into byte arrays and then
      * concatenating them together.
      * @param strings

--- a/src/test/java/com/yscope/clp/compressorfrontend/EncodingTests.java
+++ b/src/test/java/com/yscope/clp/compressorfrontend/EncodingTests.java
@@ -82,6 +82,13 @@ public class EncodingTests {
     // Test decoding from byte arrays
     decodedMessage = messageDecoder.decodeMessage(
         encodedMessage.getLogtype(),
+        FlattenedByteArrayFactory.fromByteArrays(encodedMessage.getDictionaryVarsAsBytes()),
+        encodedMessage.getEncodedVars()
+    );
+    assertEquals(originalMessage, decodedMessage);
+
+    decodedMessage = messageDecoder.decodeMessage(
+        encodedMessage.getLogtype(),
         encodedMessage.getDictionaryVarsAsFlattenedByteArray(),
         encodedMessage.getEncodedVars()
     );

--- a/src/test/java/com/yscope/clp/compressorfrontend/EncodingTests.java
+++ b/src/test/java/com/yscope/clp/compressorfrontend/EncodingTests.java
@@ -82,7 +82,7 @@ public class EncodingTests {
     // Test decoding from byte arrays
     decodedMessage = messageDecoder.decodeMessage(
         encodedMessage.getLogtype(),
-        FlattenedByteArrayFactory.fromByteArrays(encodedMessage.getDictionaryVarsAsBytes()),
+        FlattenedByteArrayFactory.fromByteArrays(encodedMessage.getDictionaryVarsAsByteArrays()),
         encodedMessage.getEncodedVars()
     );
     assertEquals(originalMessage, decodedMessage);


### PR DESCRIPTION
# Description
Add support for retrieving dictionary variables as byte[][], reducing unnecessary String encoding/decoding operations and minimizing garbage creation on the heap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced two new methods in the `EncodedMessage` class to retrieve dictionary variables as byte arrays, enhancing data representation options.
  - Added a method in the `FlattenedByteArrayFactory` to create a flattened byte array from two-dimensional byte arrays, streamlining array handling.
  - Implemented a method in `EmptyArrayUtils` to return an empty byte array if a null array is provided, improving null handling.

- **Bug Fixes**
  - Enhanced the `EncodingTests` to support decoding from byte arrays, ensuring accurate message retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->