### PR TITLE
Fix incorrect name in `EmptyArrayUtils` introduced in #53.

### DIFF
--- a/src/main/java/com/yscope/clp/compressorfrontend/EmptyArrayUtils.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/EmptyArrayUtils.java
@@ -24,7 +24,7 @@ public class EmptyArrayUtils {
     return (null == longArray) ? EMPTY_LONG_ARRAY : longArray;
   }
 
-  public static byte[][] getEmptyByteArrayArray(byte[][] byteArrayArray) {
+  public static byte[][] getNonNullByteArrayArray(byte[][] byteArrayArray) {
     return (null == byteArrayArray) ? EMPTY_BYTE_ARRAY_ARRAY : byteArrayArray;
   }
 


### PR DESCRIPTION
# Description
`EmptyArrayUtils#getEmptyByteArrayArray` -> `EmptyArrayUtils#getNonNullByteArrayArray`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated method name for clarity: `getEmptyByteArrayArray` is now `getNonNullByteArrayArray`, improving understanding of its functionality. 

- **Bug Fixes**
	- No functional changes were made; the method continues to handle null inputs as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->