### PR TITLE
bug-fix: Initialize `ThreadLocal` static member variables on declaration (fixes 55).

### DIFF
--- a/src/main/java/com/yscope/clp/compressorfrontend/FlattenedByteArrayFactory.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/FlattenedByteArrayFactory.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 
 public class FlattenedByteArrayFactory {
-    private static ThreadLocal<ByteArrayOutputStream> reusableByteArrayOutputStream;
+    private static ThreadLocal<ByteArrayOutputStream> reusableByteArrayOutputStream = ThreadLocal.withInitial(ByteArrayOutputStream::new);
 
     /**
      * Constructs a FlattenedByteArray by concatenating the given byte arrays together.
@@ -46,14 +46,8 @@ public class FlattenedByteArrayFactory {
             return EmptyArrayUtils.EMPTY_FLATTENED_BYTE_ARRAY;
         }
 
-        ByteArrayOutputStream outputStream;
-        if (null == reusableByteArrayOutputStream) {
-            outputStream = new ByteArrayOutputStream();
-            reusableByteArrayOutputStream = ThreadLocal.withInitial(() -> outputStream);
-        } else {
-            outputStream = reusableByteArrayOutputStream.get();
-            outputStream.reset();
-        }
+        ByteArrayOutputStream outputStream = reusableByteArrayOutputStream.get();
+        outputStream.reset();
 
         int[] elemEndOffsets = new int[strings.length];
         for (int i = 0; i < strings.length; ++i) {

--- a/src/main/java/com/yscope/clp/compressorfrontend/FlattenedByteArrayFactory.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/FlattenedByteArrayFactory.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 
 public class FlattenedByteArrayFactory {
-    private static ThreadLocal<ByteArrayOutputStream> reusableByteArrayOutputStream = ThreadLocal.withInitial(ByteArrayOutputStream::new);
+    private static final ThreadLocal<ByteArrayOutputStream> reusableByteArrayOutputStream = ThreadLocal.withInitial(ByteArrayOutputStream::new);
 
     /**
      * Constructs a FlattenedByteArray by concatenating the given byte arrays together.

--- a/src/main/java/com/yscope/clp/compressorfrontend/FlattenedByteArrayFactory.java
+++ b/src/main/java/com/yscope/clp/compressorfrontend/FlattenedByteArrayFactory.java
@@ -4,7 +4,8 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 
 public class FlattenedByteArrayFactory {
-    private static final ThreadLocal<ByteArrayOutputStream> reusableByteArrayOutputStream = ThreadLocal.withInitial(ByteArrayOutputStream::new);
+    private static final ThreadLocal<ByteArrayOutputStream> reusableByteArrayOutputStream =
+            ThreadLocal.withInitial(ByteArrayOutputStream::new);
 
     /**
      * Constructs a FlattenedByteArray by concatenating the given byte arrays together.


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#55

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
We use `ThreadLocal` to create a reusable per-thread data structure to flatten string arrays. However, this variable was initialized when it was first used, which introduced data race problems and caused failures in #55. This PR fixes the problem by initializing the per-thread data structure on the declaration.


# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure workflow passed.
- Tested locally (Ubuntu 22.04) to ensure CLP integration unit tests all passed in Pinot.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced the efficiency of byte array handling by implementing thread-local storage for output streams, ensuring better performance and clarity in processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->